### PR TITLE
Revert "simplified DI (implicitly passing Application obj)"

### DIFF
--- a/app/controllers/VatRegistrationController.scala
+++ b/app/controllers/VatRegistrationController.scala
@@ -16,18 +16,21 @@
 
 package controllers
 
+import javax.inject.{Inject, Singleton}
+
 import auth.VatTaxRegime
 import config.FrontendAuthConnector
-import play.api.Application
+import play.api.Configuration
 import play.api.i18n.{I18nSupport, MessagesApi}
 import uk.gov.hmrc.play.frontend.auth.Actions
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
-abstract class VatRegistrationController(implicit app: Application) extends FrontendController with I18nSupport with Actions {
+abstract class VatRegistrationController(ds: CommonPlayDependencies) extends FrontendController with I18nSupport with Actions {
 
   //$COVERAGE-OFF$
-  implicit lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  lazy val conf: Configuration = ds.conf
+  implicit lazy val messagesApi: MessagesApi = ds.messagesApi
   override val authConnector: AuthConnector = FrontendAuthConnector
   //$COVERAGE-ON$
 
@@ -47,3 +50,6 @@ abstract class VatRegistrationController(implicit app: Application) extends Fron
   protected def authorised: AuthenticatedBy = AuthorisedFor(taxRegime = VatTaxRegime, pageVisibility = GGConfidence)
 
 }
+
+@Singleton
+final class CommonPlayDependencies @Inject()(val conf: Configuration, val messagesApi: MessagesApi)

--- a/app/controllers/feedback/FeedbackController.scala
+++ b/app/controllers/feedback/FeedbackController.scala
@@ -18,11 +18,10 @@ package controllers.feedback
 
 import javax.inject.Inject
 
-import controllers.VatRegistrationController
-import play.api.Application
+import controllers.{CommonPlayDependencies, VatRegistrationController}
 import play.api.mvc._
 
-class FeedbackController @Inject()(implicit app: Application) extends VatRegistrationController {
+class FeedbackController @Inject()(ds: CommonPlayDependencies) extends VatRegistrationController(ds) {
 
   def show: Action[AnyContent] = authorised(implicit user => implicit request => Ok(views.html.pages.welcome()))
 

--- a/app/controllers/userJourney/SignInOutController.scala
+++ b/app/controllers/userJourney/SignInOutController.scala
@@ -18,11 +18,12 @@ package controllers.userJourney
 
 import javax.inject.Inject
 
-import controllers.VatRegistrationController
-import play.api.Application
+import config.FrontendAuthConnector
+import controllers.{CommonPlayDependencies, VatRegistrationController}
 import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 
-class SignInOutController @Inject()(implicit app: Application) extends VatRegistrationController {
+class SignInOutController @Inject()(ds: CommonPlayDependencies) extends VatRegistrationController(ds) {
 
   def postSignIn: Action[AnyContent] = authorised {
     implicit user =>

--- a/app/controllers/userJourney/TaxableTurnoverController.scala
+++ b/app/controllers/userJourney/TaxableTurnoverController.scala
@@ -18,11 +18,10 @@ package controllers.userJourney
 
 import javax.inject.Inject
 
-import controllers.VatRegistrationController
-import play.api.Application
+import controllers.{CommonPlayDependencies, VatRegistrationController}
 import play.api.mvc._
 
-class TaxableTurnoverController @Inject()(implicit app: Application) extends VatRegistrationController {
+class TaxableTurnoverController @Inject()(ds: CommonPlayDependencies) extends VatRegistrationController(ds) {
 
   def show: Action[AnyContent] = authorised(implicit user => implicit request => Ok(views.html.pages.taxable_turnover()))
 

--- a/app/controllers/userJourney/WelcomeController.scala
+++ b/app/controllers/userJourney/WelcomeController.scala
@@ -18,11 +18,10 @@ package controllers.userJourney
 
 import javax.inject.Inject
 
-import controllers.VatRegistrationController
-import play.api.Application
+import controllers.{CommonPlayDependencies, VatRegistrationController}
 import play.api.mvc._
 
-class WelcomeController @Inject()(implicit app: Application) extends VatRegistrationController {
+class WelcomeController @Inject()(ds: CommonPlayDependencies) extends VatRegistrationController(ds) {
 
   //access to root of application should by default direct the user to the proper URL for start of VAT registration
   def show: Action[AnyContent] = Action(implicit request => Redirect(routes.WelcomeController.start()))

--- a/test/controllers/VatRegistrationControllerSpec.scala
+++ b/test/controllers/VatRegistrationControllerSpec.scala
@@ -24,7 +24,7 @@ import play.api.test.Helpers.{redirectLocation, status, _}
 
 class VatRegistrationControllerSpec extends VatRegSpec {
 
-  object TestController extends VatRegistrationController {
+  object TestController extends VatRegistrationController(ds) {
 
     override val authConnector = mockAuthConnector
 

--- a/test/controllers/feedback/FeedbackControllerSpec.scala
+++ b/test/controllers/feedback/FeedbackControllerSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.Helpers._
 
 class FeedbackControllerSpec extends VatRegSpec {
 
-  object TestController extends FeedbackController {
+  object TestController extends FeedbackController(ds) {
     override val authConnector = mockAuthConnector
   }
 
@@ -31,7 +31,7 @@ class FeedbackControllerSpec extends VatRegSpec {
   "GET /feedback" should {
 
     "redirect to GG sign in when not authorized" in {
-      val result = new FeedbackController().show()(fakeRequest)
+      val result = new FeedbackController(ds).show()(fakeRequest)
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(authUrl)
     }

--- a/test/controllers/userJourney/SignInOutControllerSpec.scala
+++ b/test/controllers/userJourney/SignInOutControllerSpec.scala
@@ -21,7 +21,7 @@ import play.api.test.Helpers._
 
 class SignInOutControllerSpec extends VatRegSpec {
 
-  object TestController extends SignInOutController {
+  object TestController extends SignInOutController(ds) {
     override val authConnector = mockAuthConnector
   }
 

--- a/test/controllers/userJourney/TaxableTurnoverControllerSpec.scala
+++ b/test/controllers/userJourney/TaxableTurnoverControllerSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.Helpers._
 
 class TaxableTurnoverControllerSpec extends VatRegSpec {
 
-  object TestController extends TaxableTurnoverController {
+  object TestController extends TaxableTurnoverController(ds) {
     override val authConnector = mockAuthConnector
   }
 

--- a/test/controllers/userJourney/WelcomeControllerSpec.scala
+++ b/test/controllers/userJourney/WelcomeControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 
 class WelcomeControllerSpec extends VatRegSpec {
 
-  object TestController extends WelcomeController {
+  object TestController extends WelcomeController(ds) {
     override val authConnector = mockAuthConnector
   }
 
@@ -47,7 +47,7 @@ class WelcomeControllerSpec extends VatRegSpec {
   "GET /" should {
 
     "redirect the user to start page" in {
-      val result = new WelcomeController().show(fakeRequest)
+      val result = new WelcomeController(ds).show(fakeRequest)
       status(result) mustBe SEE_OTHER
       inside(redirectLocation(result)) {
         case Some(redirectUri) => redirectUri mustBe routes.WelcomeController.start().toString

--- a/test/helpers/VatRegSpec.scala
+++ b/test/helpers/VatRegSpec.scala
@@ -17,6 +17,7 @@
 package helpers
 
 import builders.AuthBuilder
+import controllers.CommonPlayDependencies
 import fixtures.LoginFixture
 import mocks.VatRegMocks
 import org.scalatest.Inside
@@ -32,6 +33,7 @@ class VatRegSpec extends PlaySpec with OneAppPerSuite with MockitoSugar with Vat
   // Placeholder for custom configuration
   // Use this if you want to configure the app
   // implicit override lazy val app: Application = new GuiceApplicationBuilder().configure().build()
+  var ds: CommonPlayDependencies = app.injector.instanceOf[CommonPlayDependencies]
 
   def callAuthorised(a: Action[AnyContent], ac: AuthConnector)(test: Future[Result] => Any): Unit =
     AuthBuilder.withAuthorisedUser(a, ac)(test)


### PR DESCRIPTION
This reverts commit 0b98af806e07739cb11c28d71da468f38d0b5019.

It is not a good idea to reference the app.injector in controllers (while here it worked, later we'd be in trouble)