### PR TITLE
improve ScrsAddress equality check

### DIFF
--- a/app/models/api/ScrsAddress.scala
+++ b/app/models/api/ScrsAddress.scala
@@ -36,9 +36,12 @@ case class ScrsAddress(
 
   val asLabel: String = inline show this
 
-  // TODO consider making case-insensitive
   override def equals(obj: Any): Boolean = obj match {
-    case ScrsAddress(`line1`, _, _, _, `postcode`, `country`) => true
+    case ScrsAddress(objLine1, _, _, _, Some(objPostcode), _)
+      if objPostcode != "" => line1.equalsIgnoreCase(objLine1) && postcode.getOrElse("").equalsIgnoreCase(objPostcode)
+    case ScrsAddress(objLine1, _, _, _, None, Some(objCountry))
+      if objCountry != "" => line1.equalsIgnoreCase(objLine1) && country.getOrElse("").equalsIgnoreCase(objCountry)
+
     case _ => false
   }
 
@@ -58,6 +61,7 @@ object ScrsAddress {
   private def normalisedSeq(address: ScrsAddress): Seq[String] = {
     import cats.instances.option._
     import cats.syntax.applicative._
+
     Seq[Option[AddressLineOrPostcode]](
       address.line1.pure.map(AddressLine),
       address.line2.pure.map(AddressLine),

--- a/app/models/api/ScrsAddress.scala
+++ b/app/models/api/ScrsAddress.scala
@@ -45,7 +45,7 @@ case class ScrsAddress(
     case _ => false
   }
 
-  override def hashCode: Int = (line1, postcode, country).##
+  override def hashCode: Int = asLabel.##
 }
 
 object ScrsAddress {

--- a/test/models/api/ScrsAddressTest.scala
+++ b/test/models/api/ScrsAddressTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.api
+
+import org.scalatest._
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ScrsAddressTest extends UnitSpec with Matchers {
+
+  "equals" should {
+    "match given same line1 and postcode" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, Some("AA1 1AA"), None)
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, Some("AA1 1AA"), None)
+      a1 shouldBe a2
+    }
+
+    "not match given same line1 and different postcode" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, Some("AA1 1AA"), None)
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, Some("AA2 1AA"), None)
+      a1 should not equal a2
+    }
+
+    "not match given different line1 and same postcode" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, Some("AA1 1AA"), None)
+      val a2 = ScrsAddress("9 Address Line", "line 2", None, None, Some("AA1 1AA"), None)
+      a1 should not equal a2
+    }
+
+    "match given same line1 and country" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some("Slovakia"))
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some("Slovakia"))
+      a1 shouldBe a2
+    }
+
+    "not match given same line1 and different country" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some("Slovakia"))
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some("Romania"))
+      a1 should not equal a2
+    }
+
+    "not match given different line1 and same country" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some("Slovakia"))
+      val a2 = ScrsAddress("9 Address Line", "line 2", None, None, None, Some("Slovakia"))
+      a1 should not equal a2
+    }
+
+  }
+
+  "equals (edge case)" should {
+    "not match given same line1 and postcode is empty/None" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, Some(""), None)
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, None, None)
+      a1 should not equal a2
+    }
+
+    "not match given same line1 and country is empty/None" in {
+      val a1 = ScrsAddress("1 Address Line", "line 2", None, None, None, Some(""))
+      val a2 = ScrsAddress("1 Address Line", "line 2", None, None, None, None)
+      a1 should not equal a2
+    }
+  }
+}

--- a/test/models/external/CoHoRegisteredOfficeAddressSpec.scala
+++ b/test/models/external/CoHoRegisteredOfficeAddressSpec.scala
@@ -53,7 +53,7 @@ class CoHoRegisteredOfficeAddressSpec extends UnitSpec {
       "address_line_1",
       None,
       "locality",
-      None, None, None, None)
+      None, None, Some("postal_code"), None)
 
   val scsrAddress = ScrsAddress("premises address_line_1", "address_line_2 po_box", Some("locality"),Some("region"),Some("postal_code"),Some("country"))
 
@@ -68,7 +68,7 @@ class CoHoRegisteredOfficeAddressSpec extends UnitSpec {
       CoHoRegisteredOfficeAddress.convertToAddress(coHoRegisteredOfficeAddress) shouldBe scsrAddress
     }
     "convert a partial CoHoRegisteredOfficeAddress to a ScsrAddress" in {
-      val partial = ScrsAddress("premises address_line_1","locality")
+      val partial = ScrsAddress(line1 = "premises address_line_1",line2 = "locality", postcode = Some("postal_code"))
       CoHoRegisteredOfficeAddress.convertToAddress(coHoRegisteredOfficeAddress2) shouldBe partial
     }
   }


### PR DESCRIPTION
Improve ScrsAddress equals method to match on case insensitively.
THIS DOES BREAK equality/hashcode contract!!!!
Added equality unit tests