### PR TITLE
fixes to summary page

### DIFF
--- a/app/controllers/builders/SummaryFinancialComplianceSectionBuilder.scala
+++ b/app/controllers/builders/SummaryFinancialComplianceSectionBuilder.scala
@@ -89,6 +89,6 @@ case class SummaryFinancialComplianceSectionBuilder
       (investmentFundManagementRow, vatSicAndCompliance.exists(_.financialCompliance.flatMap(_.investmentFundManagementServices).isDefined)),
       (manageAdditionalFundsRow, vatSicAndCompliance.exists(_.financialCompliance.flatMap(_.manageFundsAdditional).isDefined))
     ),
-    vatSicAndCompliance.map(_.financialCompliance.isDefined)
+    vatSicAndCompliance.flatMap(_.financialCompliance).isDefined
   )
 }

--- a/app/controllers/builders/SummaryLabourComplianceSectionBuilder.scala
+++ b/app/controllers/builders/SummaryLabourComplianceSectionBuilder.scala
@@ -62,6 +62,6 @@ case class SummaryLabourComplianceSectionBuilder
       (temporaryContractsRow, labourCompliance.flatMap(_.temporaryContracts).isDefined),
       (skilledWorkersRow, labourCompliance.flatMap(_.skilledWorkers).isDefined)
     ),
-    vatSicAndCompliance.map(_.labourCompliance.isDefined)
+    vatSicAndCompliance.flatMap(_.labourCompliance).isDefined
   )
 }

--- a/app/controllers/builders/SummaryServiceEligibilitySectionBuilder.scala
+++ b/app/controllers/builders/SummaryServiceEligibilitySectionBuilder.scala
@@ -67,6 +67,6 @@ case class SummaryServiceEligibilitySectionBuilder
       (applyingForAnyOfRow, vatServiceEligibility.exists(_.applyingForAnyOf.isDefined)),
       (companyWillDoAnyOfRow, vatServiceEligibility.exists(_.companyWillDoAnyOf.isDefined))
     ),
-    Some(vatServiceEligibility.isDefined)
+    vatServiceEligibility.isDefined
   )
 }

--- a/app/models/view/Summary.scala
+++ b/app/models/view/Summary.scala
@@ -24,7 +24,7 @@ case class SummarySection(
                            id: String,
                            //Tuple2[SummaryRow, Boolean] -> row -> boolean indicating whether to render the row or not
                            rows: Seq[Tuple2[SummaryRow, Boolean]],
-                           display: Option[Boolean] = Some(true)
+                           display: Boolean = true
                          )
 
 case class SummaryRow(

--- a/app/views/pages/summary.scala.html
+++ b/app/views/pages/summary.scala.html
@@ -9,7 +9,7 @@
 
 
     @for(section <- summaryModel.sections) {
-        @if(section.display.exists(identity)) {
+        @if(section.display) {
             <section>
                 <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
                 <table class="check-your-answers form-group">

--- a/test/controllers/SummaryControllerSpec.scala
+++ b/test/controllers/SummaryControllerSpec.scala
@@ -61,9 +61,7 @@ class SummaryControllerSpec extends VatRegSpec with VatRegistrationFixture {
 
     "No compliance questions have been answered by user" in {
       val vs = VatScheme("ID", vatSicAndCompliance = None)
-      assertThrows[IllegalStateException] {
-        TestSummaryController.complianceSection(vs)
-      }
+      TestSummaryController.complianceSection(vs).display mustBe false
     }
 
   }


### PR DESCRIPTION
the user can get through the whole flow without answering any
compliance questions, if their SIC code selection doesn't fall into any
of the "buckets"