### PR TITLE
Refactor remove all model empty vals

### DIFF
--- a/app/common/ErrorUtil.scala
+++ b/app/common/ErrorUtil.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+object ErrorUtil {
+  def fail(logicalGroup: String): Exception =
+    new IllegalStateException(s"$logicalGroup data expected to be found in either backend or save for later")
+}

--- a/app/models/S4LModels.scala
+++ b/app/models/S4LModels.scala
@@ -157,6 +157,7 @@ object S4LTradingDetails {
               overThresholdDate = vtp.date
             )
           )),
+
         tradingName = c.tradingName.map(tnv =>
           TradingName(tnv.yesNo == TRADING_NAME_YES, tnv.tradingName)).getOrElse(error),
 

--- a/app/services/VatRegistrationService.scala
+++ b/app/services/VatRegistrationService.scala
@@ -16,17 +16,14 @@
 
 package services
 
-import java.time.LocalDate
 import javax.inject.Inject
 
-import cats.data.OptionT
 import com.google.inject.ImplementedBy
 import common.ErrorUtil.fail
 import connectors.{CompanyRegistrationConnector, OptionalResponse, VatRegistrationConnector}
 import models.ModelKeys._
 import models._
 import models.api._
-import models.external.CoHoCompanyProfile
 import models.external.{CoHoCompanyProfile, IncorporationInfo}
 import play.api.libs.json.Format
 import uk.gov.hmrc.play.http.HeaderCarrier

--- a/app/services/VatRegistrationService.scala
+++ b/app/services/VatRegistrationService.scala
@@ -19,11 +19,11 @@ package services
 import javax.inject.Inject
 
 import com.google.inject.ImplementedBy
+import common.ErrorUtil.fail
 import connectors.{CompanyRegistrationConnector, OptionalResponse, VatRegistrationConnector}
 import models._
 import models.api._
 import models.external.CoHoCompanyProfile
-import models.view.vatFinancials.EstimateVatTurnover
 import play.api.libs.json.Format
 import uk.gov.hmrc.play.http.HeaderCarrier
 
@@ -85,7 +85,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LVatFinancials], vs: VatScheme): VatFinancials =
       fresh.fold(
         vs.financials.getOrElse(throw fail("VatFinancials"))
-      ) (s4l => S4LVatFinancials.apiT.toApi(s4l, VatFinancials.empty)) //TODO remove the "seeding" with empty
+      ) (s4l => S4LVatFinancials.apiT.toApi(s4l))
 
     for {
       (vs, vf) <- (getVatScheme() |@| s4l[S4LVatFinancials]()).tupled
@@ -97,7 +97,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LVatSicAndCompliance], vs: VatScheme) =
       fresh.fold(
         vs.vatSicAndCompliance.getOrElse(throw fail("VatSicAndCompliance"))
-      ) ( s4l => S4LVatSicAndCompliance.apiT.toApi(s4l, VatSicAndCompliance.empty)) //TODO remove the "seeding" with empty
+      ) (s4l => S4LVatSicAndCompliance.apiT.toApi(s4l))
 
     for {
       (vs, vsc) <- (getVatScheme() |@| s4l[S4LVatSicAndCompliance]()).tupled
@@ -109,7 +109,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LTradingDetails], vs: VatScheme): VatTradingDetails =
       fresh.fold(
         vs.tradingDetails.getOrElse(throw fail("VatTradingDetails"))
-      ) (s4l => S4LTradingDetails.apiT.toApi(s4l, VatTradingDetails.empty)) //TODO remove the "seeding" with empty
+      ) (s4l => S4LTradingDetails.apiT.toApi(s4l))
 
     for {
       (vs, vlo) <- (getVatScheme() |@| s4l[S4LTradingDetails]()).tupled
@@ -121,7 +121,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LVatContact], vs: VatScheme): VatContact =
       fresh.fold(
         vs.vatContact.getOrElse(throw fail("VatContact"))
-      ) (s4l => S4LVatContact.apiT.toApi(s4l, VatContact.empty)) //TODO remove the "seeding" with empty
+      ) (s4l => S4LVatContact.apiT.toApi(s4l))
 
     for {
       (vs, vlo) <- (getVatScheme() |@| s4l[S4LVatContact]()).tupled
@@ -133,7 +133,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LVatEligibility], vs: VatScheme): VatServiceEligibility =
       fresh.fold(
         vs.vatServiceEligibility.getOrElse(throw fail("VatServiceEligibility"))
-      ) ( s4l => S4LVatEligibility.apiT.toApi(s4l, VatServiceEligibility()))
+      ) (s4l => S4LVatEligibility.apiT.toApi(s4l))
 
     for {
       (vs, ve) <- (getVatScheme() |@| s4l[S4LVatEligibility]()).tupled
@@ -145,7 +145,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LVatLodgingOfficer], vs: VatScheme): VatLodgingOfficer =
       fresh.fold(
         vs.lodgingOfficer.getOrElse(throw fail("VatLodgingOfficer"))
-      ) ( s4l => S4LVatLodgingOfficer.apiT.toApi(s4l, VatLodgingOfficer.empty)) //TODO remove the "seeding" with empty
+      ) ( s4l => S4LVatLodgingOfficer.apiT.toApi(s4l))
 
     for {
       (vs, vlo) <- (getVatScheme() |@| s4l[S4LVatLodgingOfficer]()).tupled
@@ -157,7 +157,7 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     def merge(fresh: Option[S4LFlatRateScheme], vs: VatScheme): VatFlatRateScheme =
       fresh.fold(
         vs.vatFlatRateScheme.getOrElse(throw fail("VatFlatRateScheme"))
-      ) ( s4l => S4LFlatRateScheme.apiT.toApi(s4l, VatFlatRateScheme()) )
+      ) (s4l => S4LFlatRateScheme.apiT.toApi(s4l))
 
     for {
       (vs, frs) <- (getVatScheme() |@| s4l[S4LFlatRateScheme]()).tupled
@@ -165,6 +165,4 @@ class VatRegistrationService @Inject()(s4LService: S4LService,
     } yield response
   }
 
-  private def fail(logicalGroup: String): Exception =
-    new IllegalStateException(s"$logicalGroup data expected to be found in either backend or save for later")
 }

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -73,6 +73,7 @@ trait VatRegistrationFixture {
     digitalContact = VatDigitalContact(email = "asd@com", tel = Some("123"), mobile = None),
     website = None,
     ppob = scrsAddress)
+
   val validVatThresholdPostIncorp = VatThresholdPostIncorp(overThresholdSelection = false, None)
 
   private val turnoverEstimate = 50000L

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -144,7 +144,7 @@ trait VatRegistrationFixture {
                       tradingName: Option[String] = Some("ACME Ltd."),
                       reason: Option[String] = None,
                       euGoodsSelection: Boolean = true,
-                      eoriApplication: Option[Boolean] = None
+                      eoriApplication: Option[Boolean] = Some(true)
                     ): VatTradingDetails = VatTradingDetails(
     vatChoice = VatChoice(
       necessity = necessity,

--- a/test/models/S4LModelsSpec.scala
+++ b/test/models/S4LModelsSpec.scala
@@ -157,7 +157,8 @@ class S4LModelsSpec  extends UnitSpec with Inspectors with VatRegistrationFixtur
       voluntaryRegistration = Some(VoluntaryRegistration(REGISTER_YES)),
       voluntaryRegistrationReason = Some(VoluntaryRegistrationReason(INTENDS_TO_SELL)),
       euGoods = Some(EuGoods(EU_GOODS_YES)),
-      applyEori = Some(ApplyEori(APPLY_EORI_YES))
+      applyEori = Some(ApplyEori(APPLY_EORI_YES)),
+      overThreshold = Some(OverThresholdView(false, None))
     )
 
     "transform complete S4L with voluntary registration model to API" in {
@@ -180,14 +181,10 @@ class S4LModelsSpec  extends UnitSpec with Inspectors with VatRegistrationFixtur
         vatChoice = VatChoice(
           necessity = NECESSITY_OBLIGATORY,
           vatStartDate = VatStartDate(selection = SPECIFIC_DATE, startDate = Some(specificDate)),
-          reason = None),
+          reason = None,
+          vatThresholdPostIncorp = Some(validVatThresholdPostIncorp)),
         tradingName = TradingName(selection = true, tradingName = Some(tradingName)),
         euTrading = VatEuTrading(selection = true, eoriApplication = Some(true))
-          vatStartDate = VatStartDate(selection = BUSINESS_START_DATE, startDate = Some(ctDate)),
-          reason = None,
-          vatThresholdPostIncorp = Some(validVatThresholdPostIncorp.copy(overThresholdSelection = true, overThresholdDate = Some(testDate)))),
-        tradingName = TradingName(selection = false, tradingName = None),
-        euTrading = VatEuTrading(selection = false, eoriApplication = None)
       )
 
       val s4lMandatoryBydefault = s4l.copy(voluntaryRegistration = None, voluntaryRegistrationReason = None)


### PR DESCRIPTION
phase 1 - modify S4LApiTransformer.toApi  to not require a VatLogicalGroup parameter (which is main use-case for model empty vals)