### PR TITLE
Every page has 1 of the following arrangements of parent wrapper

### DIFF
--- a/app/features/financials/views/estimate_vat_turnover.scala.html
+++ b/app/features/financials/views/estimate_vat_turnover.scala.html
@@ -8,63 +8,58 @@
 
 @main_template(title = messages("pages.estimate.vat.turnover.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    messages("app.common.errorSummaryLabel"),
+    estimateVatTurnoverForm,
+    Seq("turnoverEstimate")
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      estimateVatTurnoverForm,
-      Seq("turnoverEstimate")
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.estimate.vat.turnover.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.estimate.vat.turnover.heading")</h1>
+  <div class="form-group">
+      <div class="panel indent">
+          <p>@messages("pages.estimate.vat.turnover.info")</p>
+      </div>
+  </div>
 
-      <div class="form-group">
-          <div class="panel indent">
-              <p>@messages("pages.estimate.vat.turnover.info")</p>
-          </div>
+  <details role="group">
+      <summary role="button" aria-controls="details-content-1" aria-expanded="false">
+          <span class="summary">
+            @Html(messages("pages.estimate.vat.turnover.include.title"))
+          </span>
+      </summary>
+      <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+          <ul class="list list-bullet">
+              <li>@Html(messages("pages.estimate.vat.turnover.include.bullet1"))</li>
+              <li>@Html(messages("pages.estimate.vat.turnover.include.bullet2"))</li>
+              <li>@Html(messages("pages.estimate.vat.turnover.include.bullet3"))</li>
+              <li>@Html(messages("pages.estimate.vat.turnover.include.bullet4"))</li>
+          </ul>
+          <p>@Html(messages("pages.estimate.vat.turnover.include.para1"))</p>
+      </div>
+  </details>
+
+  @govHelpers.form(action = controllers.vatFinancials.routes.EstimateVatTurnoverController.submit()) {
+      <div class="form-group @fieldSetClasses">
+          <fieldset>
+              @estimateVatTurnoverForm.errors.find(_.args.contains("turnoverEstimate")).map { error =>
+                  @govHelpers.errorInline("turnoverEstimate", messages(error.message))
+              }
+
+              @vatInput(
+                  estimateVatTurnoverForm("turnoverEstimate"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_label -> messages("app.common.gbp.symbol"),
+                  '_labelClass -> "form-label"
+              )
+          </fieldset>
       </div>
 
-      <details role="group">
-          <summary role="button" aria-controls="details-content-1" aria-expanded="false">
-              <span class="summary">
-                @Html(messages("pages.estimate.vat.turnover.include.title"))
-              </span>
-          </summary>
-          <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
-              <ul class="list list-bullet">
-                  <li>@Html(messages("pages.estimate.vat.turnover.include.bullet1"))</li>
-                  <li>@Html(messages("pages.estimate.vat.turnover.include.bullet2"))</li>
-                  <li>@Html(messages("pages.estimate.vat.turnover.include.bullet3"))</li>
-                  <li>@Html(messages("pages.estimate.vat.turnover.include.bullet4"))</li>
-              </ul>
-              <p>@Html(messages("pages.estimate.vat.turnover.include.para1"))</p>
-          </div>
-      </details>
-
-      @govHelpers.form(action = controllers.vatFinancials.routes.EstimateVatTurnoverController.submit()) {
-          <div class="form-group @fieldSetClasses">
-              <fieldset>
-                  @estimateVatTurnoverForm.errors.find(_.args.contains("turnoverEstimate")).map { error =>
-                      @govHelpers.errorInline("turnoverEstimate", messages(error.message))
-                  }
-
-                  @vatInput(
-                      estimateVatTurnoverForm("turnoverEstimate"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_label -> messages("app.common.gbp.symbol"),
-                      '_labelClass -> "form-label"
-                  )
-              </fieldset>
-          </div>
-
-          <div class="form-group">
-              <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-          </div>
-      }
-
-    </div>
-
+      <div class="form-group">
+          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+      </div>
+  }
 }
 
 <script type="text/javascript">

--- a/app/features/financials/views/estimate_zero_rated_sales.scala.html
+++ b/app/features/financials/views/estimate_zero_rated_sales.scala.html
@@ -8,65 +8,60 @@
 
 @main_template(title = messages("pages.estimate.zero.rated.sales.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    estimateZeroRatedSalesForm,
+    Seq("zeroRatedTurnoverEstimate")
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      estimateZeroRatedSalesForm,
-      Seq("zeroRatedTurnoverEstimate")
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.estimate.zero.rated.sales.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.estimate.zero.rated.sales.heading")</h1>
-
-      <div class="panel panel-indent" id="details-content-1" aria-hidden="false">
-          <p>@messages("pages.estimate.zero.rated.sales.p1")</p>
+  <div class="panel panel-indent" id="details-content-1" aria-hidden="false">
+      <p>@messages("pages.estimate.zero.rated.sales.p1")</p>
+  </div>
+  <details role="group">
+      <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">
+      @Html(messages("pages.estimate.zero.rated.sales.include.title"))
+      </span></summary>
+      <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+          <p>@messages("pages.estimate.zero.rated.sales.include.para1")</p>
+          <p>@messages("pages.estimate.zero.rated.sales.include.para2")</p>
+          <ul class="list list-bullet">
+              <li>@messages("pages.estimate.zero.rated.sales.include.bullet1")</li>
+              <li>@messages("pages.estimate.zero.rated.sales.include.bullet2")</li>
+              <li>@messages("pages.estimate.zero.rated.sales.include.bullet3")</li>
+              <li>@messages("pages.estimate.zero.rated.sales.include.bullet4")</li>
+              <li>@messages("pages.estimate.zero.rated.sales.include.bullet5")</li>
+          </ul>
+          <p>@Html(Messages("pages.estimate.zero.rated.sales.include.para3"))</p>
       </div>
-      <details role="group">
-          <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">
-          @Html(messages("pages.estimate.zero.rated.sales.include.title"))
-          </span></summary>
-          <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
-              <p>@messages("pages.estimate.zero.rated.sales.include.para1")</p>
-              <p>@messages("pages.estimate.zero.rated.sales.include.para2")</p>
-              <ul class="list list-bullet">
-                  <li>@messages("pages.estimate.zero.rated.sales.include.bullet1")</li>
-                  <li>@messages("pages.estimate.zero.rated.sales.include.bullet2")</li>
-                  <li>@messages("pages.estimate.zero.rated.sales.include.bullet3")</li>
-                  <li>@messages("pages.estimate.zero.rated.sales.include.bullet4")</li>
-                  <li>@messages("pages.estimate.zero.rated.sales.include.bullet5")</li>
-              </ul>
-              <p>@Html(Messages("pages.estimate.zero.rated.sales.include.para3"))</p>
-          </div>
-      </details>
-      @govHelpers.form(action = controllers.vatFinancials.routes.EstimateZeroRatedSalesController.submit()) {
-          <div class="form-group @fieldSetClasses">
-              <fieldset>
+  </details>
+  @govHelpers.form(action = controllers.vatFinancials.routes.EstimateZeroRatedSalesController.submit()) {
+      <div class="form-group @fieldSetClasses">
+          <fieldset>
 
-                  @estimateZeroRatedSalesForm.errors.find(_.args.contains("zeroRatedTurnoverEstimate")).map { error =>
-                      @govHelpers.errorInline("zeroRatedTurnoverEstimate", Messages(error.message))
-                  }
+              @estimateZeroRatedSalesForm.errors.find(_.args.contains("zeroRatedTurnoverEstimate")).map { error =>
+                  @govHelpers.errorInline("zeroRatedTurnoverEstimate", Messages(error.message))
+              }
 
-                      @vatInput(
-                          estimateZeroRatedSalesForm("zeroRatedTurnoverEstimate"),
-                          '_divClass -> "form-group",
-                          '_inputClass -> "form-control",
-                          '_label -> Messages("app.common.gbp.symbol"),
-                          '_labelClass -> "form-label"
-                      )
+                  @vatInput(
+                      estimateZeroRatedSalesForm("zeroRatedTurnoverEstimate"),
+                      '_divClass -> "form-group",
+                      '_inputClass -> "form-control",
+                      '_label -> Messages("app.common.gbp.symbol"),
+                      '_labelClass -> "form-label"
+                  )
 
 
-              </fieldset>
+          </fieldset>
 
 
-          </div>
+      </div>
 
-          <div class="form-group">
-              <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-          </div>
-      }
-
-    </div>
-
+      <div class="form-group">
+          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+      </div>
+  }
 }
 
 <script type="text/javascript">

--- a/app/features/financials/views/vatAccountingPeriod/accounting_period.scala.html
+++ b/app/features/financials/views/vatAccountingPeriod/accounting_period.scala.html
@@ -8,46 +8,41 @@
 
 @main_template(title = messages("pages.accounting.period.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    accountingPeriodForm,
+    Seq("accountingPeriodRadio")
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      accountingPeriodForm,
-      Seq("accountingPeriodRadio")
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.accounting.period.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.accounting.period.heading")</h1>
+  <p>@Html(Messages("pages.accounting.period.para1"))</p>
 
-      <p>@Html(Messages("pages.accounting.period.para1"))</p>
+  @govHelpers.form(action = controllers.vatFinancials.vatAccountingPeriod.routes.AccountingPeriodController.submit()) {
+  <div class="form-group @fieldSetClasses">
+    <fieldset class="block">
+        <span id="accountingPeriodRadio"/>
+        @accountingPeriodForm.errors.find(_.args.contains("accountingPeriodRadio")).map { error =>
+            @govHelpers.errorInline("accountingPeriodRadio", Messages(error.message))
+        }
 
-      @govHelpers.form(action = controllers.vatFinancials.vatAccountingPeriod.routes.AccountingPeriodController.submit()) {
-      <div class="form-group @fieldSetClasses">
-        <fieldset class="block">
-            <span id="accountingPeriodRadio"/>
-            @accountingPeriodForm.errors.find(_.args.contains("accountingPeriodRadio")).map { error =>
-                @govHelpers.errorInline("accountingPeriodRadio", Messages(error.message))
-            }
+        @vatInputRadioGroup(
+            field = accountingPeriodForm("accountingPeriodRadio"),
+            Seq(
+              AccountingPeriod.JAN_APR_JUL_OCT -> Messages("pages.accounting.period.radio.january"),
+              AccountingPeriod.FEB_MAY_AUG_NOV -> Messages("pages.accounting.period.radio.february"),
+              AccountingPeriod.MAR_JUN_SEP_DEC -> Messages("pages.accounting.period.radio.march")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+   
+  </div>
 
-            @vatInputRadioGroup(
-                field = accountingPeriodForm("accountingPeriodRadio"),
-                Seq(
-                  AccountingPeriod.JAN_APR_JUL_OCT -> Messages("pages.accounting.period.radio.january"),
-                  AccountingPeriod.FEB_MAY_AUG_NOV -> Messages("pages.accounting.period.radio.february"),
-                  AccountingPeriod.MAR_JUN_SEP_DEC -> Messages("pages.accounting.period.radio.march")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-       
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/financials/views/vatAccountingPeriod/vat_return_frequency.scala.html
+++ b/app/features/financials/views/vatAccountingPeriod/vat_return_frequency.scala.html
@@ -5,39 +5,32 @@
 
 @main_template(title = messages("pages.vat.return.frequency.title")) {
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    vatReturnFrequencyForm
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      vatReturnFrequencyForm
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.vat.return.frequency.heading")</h1>
+  
+  @govHelpers.form(action = controllers.vatFinancials.vatAccountingPeriod.routes.VatReturnFrequencyController.submit()) {
+  <div class="form-group">
+    <fieldset>
+      <span id="vatReturnFrequencyRadio"/>
+      @vatInputRadioGroup(
+          field = vatReturnFrequencyForm("vatReturnFrequencyRadio"),
+          Seq(
+            VatReturnFrequency.MONTHLY -> Messages("pages.vat.return.frequency.radio.monthly"),
+            VatReturnFrequency.QUARTERLY -> Messages("pages.vat.return.frequency.radio.quarterly")
+          ),
+          '_labelAfter -> true,
+          '_labelClass -> "block-label"
       )
-
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.vat.return.frequency.heading")</h1>
-      
-      @govHelpers.form(action = controllers.vatFinancials.vatAccountingPeriod.routes.VatReturnFrequencyController.submit()) {
-      <div class="form-group">
-        <fieldset>
-          <span id="vatReturnFrequencyRadio"/>
-          @vatInputRadioGroup(
-              field = vatReturnFrequencyForm("vatReturnFrequencyRadio"),
-              Seq(
-                VatReturnFrequency.MONTHLY -> Messages("pages.vat.return.frequency.radio.monthly"),
-                VatReturnFrequency.QUARTERLY -> Messages("pages.vat.return.frequency.radio.quarterly")
-              ),
-              '_labelAfter -> true,
-              '_labelClass -> "block-label"
-          )
-        </fieldset>
-      </div>
-
-        <div class="form-group">
-          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-        </div>
-      }
-
-    </div>
+    </fieldset>
   </div>
 
+    <div class="form-group">
+      <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+    </div>
+  }
 }
 

--- a/app/features/financials/views/vatBankAccount/company_bank_account.scala.html
+++ b/app/features/financials/views/vatBankAccount/company_bank_account.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.company.bank.account.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    companyBankAccountForm
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      companyBankAccountForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.company.bank.account.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.company.bank.account.heading")</h1>
+  @govHelpers.form(action = controllers.vatFinancials.vatBankAccount.routes.CompanyBankAccountController.submit()) {
+  <div class="form-group">
+    <fieldset class="inline">
+        <span id="companyBankAccountRadio"/>
 
-      @govHelpers.form(action = controllers.vatFinancials.vatBankAccount.routes.CompanyBankAccountController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="companyBankAccountRadio"/>
+        @vatInputRadioGroup(
+            field = companyBankAccountForm("companyBankAccountRadio"),
+            Seq(
+              CompanyBankAccount.COMPANY_BANK_ACCOUNT_YES -> Messages("app.common.yes"),
+              CompanyBankAccount.COMPANY_BANK_ACCOUNT_NO -> Messages("app.common.no")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+  </div>
 
-            @vatInputRadioGroup(
-                field = companyBankAccountForm("companyBankAccountRadio"),
-                Seq(
-                  CompanyBankAccount.COMPANY_BANK_ACCOUNT_YES -> Messages("app.common.yes"),
-                  CompanyBankAccount.COMPANY_BANK_ACCOUNT_NO -> Messages("app.common.no")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/financials/views/vatBankAccount/company_bank_account_details.scala.html
+++ b/app/features/financials/views/vatBankAccount/company_bank_account_details.scala.html
@@ -5,115 +5,109 @@
 
 @main_template(title = messages("pages.bankDetails.title")) {
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        bankDetailsForm
+    )
 
-            @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            bankDetailsForm
-            )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.bankDetails.heading")</h1>
 
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.bankDetails.heading")</h1>
+    <p>@messages("pages.bankDetails.para1")</p>
 
-            <p>@messages("pages.bankDetails.para1")</p>
-
-            <div class="notice form-group">
-                <i class="icon icon-important">
-                    <span class="visuallyhidden">Warning</span>
-                </i>
-                <strong class="bold-small">@messages("pages.bankDetails.info")</strong>
-            </div>
-
-            @govHelpers.form(action = controllers.vatFinancials.vatBankAccount.routes.CompanyBankAccountDetailsController.submit()) {
-                <div class="form-group">
-                    <div class="form-bank-details">
-
-                        @vatInput(
-                            bankDetailsForm("accountName"),
-                            '_divClass -> "form-group",
-                            '_inputClass -> "form-control",
-                            '_labelClass -> "cascading",
-                            '_maxlength -> 150,
-                            '_inputHint -> messages("pages.bankDetails.accountName.hint"),
-                            '_label -> messages("pages.bankDetails.accountName.label"),
-                            '_autoComplete -> "off"
-                        )
-
-                        @vatInput(
-                            bankDetailsForm("accountNumber"),
-                            '_type -> "text",
-                            '_divClass -> "form-group",
-                            '_inputClass -> "form-control",
-                            '_labelClass -> "cascading",
-                            '_maxlength -> 8,
-                            '_label -> messages("pages.bankDetails.accountNumber.label"),
-                            '_autoComplete -> "off"
-                        )
-
-                        @defining(bankDetailsForm("sortCode").errors.nonEmpty) { sortCodeErrorPresent =>
-                            <div class="form-date @if(sortCodeErrorPresent) { form-group-error }">
-
-                                <fieldset id="sort-code">
-
-                                    <label>
-                                        @bankDetailsForm("sortCode").errors.map { error =>
-                                            <span class="error-notification" role="tooltip">
-                                                @messages(error.message, error.args: _*)
-                                            </span>
-                                        }
-                                        @messages("pages.bankDetails.sortCode.label")
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="text" name="sortCode" value="" id="sortCode" class="hidden" />
-                                    </label>
-
-                                    @vatInput(
-                                        bankDetailsForm("sortCode.part1"),
-                                        '_type -> "text",
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_label -> "first two digits",
-                                        '_maxlength -> 2,
-                                        '_labelTextClass -> "hidden",
-                                        '_error_id -> "sort-code-legend",
-                                        '_autoComplete -> "off"
-                                    )
-
-                                    @vatInput(
-                                        bankDetailsForm("sortCode.part2"),
-                                        '_type -> "text",
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_label -> "second two digits",
-                                        '_maxlength -> 2,
-                                        '_labelTextClass -> "hidden",
-                                        '_error_id -> "sort-code-legend",
-                                        '_autoComplete -> "off"
-                                    )
-
-                                    @vatInput(
-                                        bankDetailsForm("sortCode.part3"),
-                                        '_type -> "text",
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_label -> "last two digits",
-                                        '_maxlength -> 2,
-                                        '_labelTextClass -> "hidden",
-                                        '_error_id -> "sort-code-legend",
-                                        '_autoComplete -> "off"
-                                    )
-                                </fieldset>
-                            </div>
-                        }
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-                </div>
-            }
-
-        </div>
+    <div class="notice form-group">
+        <i class="icon icon-important">
+            <span class="visuallyhidden">Warning</span>
+        </i>
+        <strong class="bold-small">@messages("pages.bankDetails.info")</strong>
     </div>
+
+    @govHelpers.form(action = controllers.vatFinancials.vatBankAccount.routes.CompanyBankAccountDetailsController.submit()) {
+        <div class="form-group">
+            <div class="form-bank-details">
+
+                @vatInput(
+                    bankDetailsForm("accountName"),
+                    '_divClass -> "form-group",
+                    '_inputClass -> "form-control",
+                    '_labelClass -> "cascading",
+                    '_maxlength -> 150,
+                    '_inputHint -> messages("pages.bankDetails.accountName.hint"),
+                    '_label -> messages("pages.bankDetails.accountName.label"),
+                    '_autoComplete -> "off"
+                )
+
+                @vatInput(
+                    bankDetailsForm("accountNumber"),
+                    '_type -> "text",
+                    '_divClass -> "form-group",
+                    '_inputClass -> "form-control",
+                    '_labelClass -> "cascading",
+                    '_maxlength -> 8,
+                    '_label -> messages("pages.bankDetails.accountNumber.label"),
+                    '_autoComplete -> "off"
+                )
+
+                @defining(bankDetailsForm("sortCode").errors.nonEmpty) { sortCodeErrorPresent =>
+                    <div class="form-date @if(sortCodeErrorPresent) { form-group-error }">
+
+                        <fieldset id="sort-code">
+
+                            <label>
+                                @bankDetailsForm("sortCode").errors.map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                @messages("pages.bankDetails.sortCode.label")
+                                @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                <input type="text" name="sortCode" value="" id="sortCode" class="hidden" />
+                            </label>
+
+                            @vatInput(
+                                bankDetailsForm("sortCode.part1"),
+                                '_type -> "text",
+                                '_divClass -> "form-group",
+                                '_inputClass -> "form-control",
+                                '_label -> "first two digits",
+                                '_maxlength -> 2,
+                                '_labelTextClass -> "hidden",
+                                '_error_id -> "sort-code-legend",
+                                '_autoComplete -> "off"
+                            )
+
+                            @vatInput(
+                                bankDetailsForm("sortCode.part2"),
+                                '_type -> "text",
+                                '_divClass -> "form-group",
+                                '_inputClass -> "form-control",
+                                '_label -> "second two digits",
+                                '_maxlength -> 2,
+                                '_labelTextClass -> "hidden",
+                                '_error_id -> "sort-code-legend",
+                                '_autoComplete -> "off"
+                            )
+
+                            @vatInput(
+                                bankDetailsForm("sortCode.part3"),
+                                '_type -> "text",
+                                '_divClass -> "form-group",
+                                '_inputClass -> "form-control",
+                                '_label -> "last two digits",
+                                '_maxlength -> 2,
+                                '_labelTextClass -> "hidden",
+                                '_error_id -> "sort-code-legend",
+                                '_autoComplete -> "off"
+                            )
+                        </fieldset>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/financials/views/vat_charge_expectancy.scala.html
+++ b/app/features/financials/views/vat_charge_expectancy.scala.html
@@ -5,41 +5,36 @@
 
 @main_template(title = messages("pages.vat.charge.expectancy.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    vatChargeExpectancyForm
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      vatChargeExpectancyForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.vat.charge.expectancy.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.vat.charge.expectancy.heading")</h1>
+  <p>@Html(Messages("pages.vat.charge.expectancy.para1"))</p>
+  <p>@Html(Messages("pages.vat.charge.expectancy.para2"))</p>
 
-      <p>@Html(Messages("pages.vat.charge.expectancy.para1"))</p>
-      <p>@Html(Messages("pages.vat.charge.expectancy.para2"))</p>
+  @govHelpers.form(action = controllers.vatFinancials.routes.VatChargeExpectancyController.submit()) {
+  <div class="form-group">
+    <fieldset class="block">
+        <span id="vatChargeRadio"/>
+        @vatInputRadioGroup(
+            field = vatChargeExpectancyForm("vatChargeRadio"),
+            Seq(
+              VatChargeExpectancy.VAT_CHARGE_YES -> Messages("pages.vat.charge.expectancy.radio.yes"),
+              VatChargeExpectancy.VAT_CHARGE_NO -> Messages("pages.vat.charge.expectancy.radio.no")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+   
+  </div>
 
-      @govHelpers.form(action = controllers.vatFinancials.routes.VatChargeExpectancyController.submit()) {
-      <div class="form-group">
-        <fieldset class="block">
-            <span id="vatChargeRadio"/>
-            @vatInputRadioGroup(
-                field = vatChargeExpectancyForm("vatChargeRadio"),
-                Seq(
-                  VatChargeExpectancy.VAT_CHARGE_YES -> Messages("pages.vat.charge.expectancy.radio.yes"),
-                  VatChargeExpectancy.VAT_CHARGE_NO -> Messages("pages.vat.charge.expectancy.radio.no")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-       
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/financials/views/zero_rated_sales.scala.html
+++ b/app/features/financials/views/zero_rated_sales.scala.html
@@ -5,59 +5,54 @@
 
 @main_template(title = messages("pages.zero.rated.sales.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    zeroRatedSalesForm
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      zeroRatedSalesForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.zero.rated.sales.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.zero.rated.sales.heading")</h1>
+  <p>@Html(Messages("pages.zero.rated.sales.para1"))</p>
 
-      <p>@Html(Messages("pages.zero.rated.sales.para1"))</p>
+  <div class="form-group">
+      <details role="group">
+          <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">
+          @Html(messages("pages.zero.rated.sales.examples.title"))
+          </span></summary>
+          <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+              <p>@messages("pages.zero.rated.sales.examples.p1")</p>
+              <p>@messages("pages.zero.rated.sales.examples.p2")</p>
+              <ul class="list list-bullet">
+                  <li>@Html(Messages("pages.zero.rated.sales.examples.bullet1"))</li>
+                  <li>@Html(Messages("pages.zero.rated.sales.examples.bullet2"))</li>
+                  <li>@Html(Messages("pages.zero.rated.sales.examples.bullet3"))</li>
+                  <li>@Html(Messages("pages.zero.rated.sales.examples.bullet4"))</li>
+              </ul>
+              <p>@Html(Messages("pages.zero.rated.sales.examples.p3"))</p>
+          </div>
+      </details>
+  </div>
 
-      <div class="form-group">
-          <details role="group">
-              <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">
-              @Html(messages("pages.zero.rated.sales.examples.title"))
-              </span></summary>
-              <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
-                  <p>@messages("pages.zero.rated.sales.examples.p1")</p>
-                  <p>@messages("pages.zero.rated.sales.examples.p2")</p>
-                  <ul class="list list-bullet">
-                      <li>@Html(Messages("pages.zero.rated.sales.examples.bullet1"))</li>
-                      <li>@Html(Messages("pages.zero.rated.sales.examples.bullet2"))</li>
-                      <li>@Html(Messages("pages.zero.rated.sales.examples.bullet3"))</li>
-                      <li>@Html(Messages("pages.zero.rated.sales.examples.bullet4"))</li>
-                  </ul>
-                  <p>@Html(Messages("pages.zero.rated.sales.examples.p3"))</p>
-              </div>
-          </details>
-      </div>
+  @govHelpers.form(action = controllers.vatFinancials.routes.ZeroRatedSalesController.submit()) {
+  <div class="form-group">
+    <fieldset class="inline">
+        <span id="zeroRatedSalesRadio"/>
+        @vatInputRadioGroup(
+            field = zeroRatedSalesForm("zeroRatedSalesRadio"),
+            Seq(
+              ZeroRatedSales.ZERO_RATED_SALES_YES -> Messages("app.common.yes"),
+              ZeroRatedSales.ZERO_RATED_SALES_NO -> Messages("app.common.no")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+   
+  </div>
 
-      @govHelpers.form(action = controllers.vatFinancials.routes.ZeroRatedSalesController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="zeroRatedSalesRadio"/>
-            @vatInputRadioGroup(
-                field = zeroRatedSalesForm("zeroRatedSalesRadio"),
-                Seq(
-                  ZeroRatedSales.ZERO_RATED_SALES_YES -> Messages("app.common.yes"),
-                  ZeroRatedSales.ZERO_RATED_SALES_NO -> Messages("app.common.no")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-       
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/frs/views/annual_costs_inclusive.scala.html
+++ b/app/features/frs/views/annual_costs_inclusive.scala.html
@@ -5,40 +5,35 @@
 
 @main_template(title = messages("pages.frs.costsInclusive.title")) {
 
-  <div class="column-two-thirds">
+  @errorSummary(
+      Messages("app.common.errorSummaryLabel"),
+      annualCostsInclusiveForm
+  )
 
-      @errorSummary(
-          Messages("app.common.errorSummaryLabel"),
-          annualCostsInclusiveForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.costsInclusive.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.costsInclusive.heading")</h1>
+  <p>@Html(messages("pages.frs.costsInclusive.p1"))</p>
 
-      <p>@Html(messages("pages.frs.costsInclusive.p1"))</p>
+  @govHelpers.form(action = controllers.frs.routes.AnnualCostsInclusiveController.submit()) {
+  <div class="form-group">
+    <fieldset class="block">
+        <span id="annualCostsInclusiveRadio"/>
+        @vatInputRadioGroup(
+            field = annualCostsInclusiveForm("annualCostsInclusiveRadio"),
+            Seq(
+              AnnualCostsInclusiveView.YES -> messages("app.common.yes"),
+              AnnualCostsInclusiveView.YES_WITHIN_12_MONTHS -> messages("pages.frs.costsInclusive.radio2"),
+              AnnualCostsInclusiveView.NO -> messages("pages.frs.costsInclusive.radio3")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
+  </div>
 
-      @govHelpers.form(action = controllers.frs.routes.AnnualCostsInclusiveController.submit()) {
-      <div class="form-group">
-        <fieldset class="block">
-            <span id="annualCostsInclusiveRadio"/>
-            @vatInputRadioGroup(
-                field = annualCostsInclusiveForm("annualCostsInclusiveRadio"),
-                Seq(
-                  AnnualCostsInclusiveView.YES -> messages("app.common.yes"),
-                  AnnualCostsInclusiveView.YES_WITHIN_12_MONTHS -> messages("pages.frs.costsInclusive.radio2"),
-                  AnnualCostsInclusiveView.NO -> messages("pages.frs.costsInclusive.radio3")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/frs/views/annual_costs_limited.scala.html
+++ b/app/features/frs/views/annual_costs_limited.scala.html
@@ -5,43 +5,38 @@
 
 @main_template(title = messages("pages.frs.costsLimited.title")) {
 
-  <div class="column-two-thirds">
+  @errorSummary(
+      Messages("app.common.errorSummaryLabel"),
+      annualCostsInclusiveForm
+  )
 
-      @errorSummary(
-          Messages("app.common.errorSummaryLabel"),
-          annualCostsInclusiveForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">
+      @messages("pages.frs.costsLimited.heading1", "%,d".format(estimateVatTurnover))
+  </h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">
-          @messages("pages.frs.costsLimited.heading1", "%,d".format(estimateVatTurnover))
-      </h1>
+  <p>@Html(messages("pages.frs.costsLimited.p1"))</p>
 
-      <p>@Html(messages("pages.frs.costsLimited.p1"))</p>
+  @govHelpers.form(action = controllers.frs.routes.AnnualCostsLimitedController.submit()) {
+  <div class="form-group">
+    <fieldset class="block">
+        <span id="annualCostsLimitedRadio"/>
+        @vatInputRadioGroup(
+            field = annualCostsInclusiveForm("annualCostsLimitedRadio"),
+            Seq(
+              AnnualCostsLimitedView.YES -> messages("app.common.yes"),
+              AnnualCostsLimitedView.YES_WITHIN_12_MONTHS -> messages("pages.frs.costsLimited.radio2"),
+              AnnualCostsLimitedView.NO -> messages("pages.frs.costsLimited.radio3")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
 
-      @govHelpers.form(action = controllers.frs.routes.AnnualCostsLimitedController.submit()) {
-      <div class="form-group">
-        <fieldset class="block">
-            <span id="annualCostsLimitedRadio"/>
-            @vatInputRadioGroup(
-                field = annualCostsInclusiveForm("annualCostsLimitedRadio"),
-                Seq(
-                  AnnualCostsLimitedView.YES -> messages("app.common.yes"),
-                  AnnualCostsLimitedView.YES_WITHIN_12_MONTHS -> messages("pages.frs.costsLimited.radio2"),
-                  AnnualCostsLimitedView.NO -> messages("pages.frs.costsLimited.radio3")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
+    </fieldset>
+  </div>
 
-        </fieldset>
-      </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/features/frs/views/frs_confirm_business_sector.scala.html
+++ b/app/features/frs/views/frs_confirm_business_sector.scala.html
@@ -4,49 +4,43 @@
 
 @main_template(title = messages("pages.frs.confirmBusinessSector.title")) {
 
-    <div class="column-two-thirds">
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.confirmBusinessSector.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.confirmBusinessSector.heading")</h1>
+    <table class="form-group">
+        <tbody>
+            <tr>
+                <td>@messages("pages.frs.confirmBusinessSector.table.row1.heading")</td>
+                <td>@Html(businessSectorView.businessSector)</td>
+            </tr>
+            <tr>
+                <td>@messages("pages.frs.confirmBusinessSector.table.row2.heading")</td>
+                <td>@Html(businessSectorView.flatRatePercentageFormatted)</td>
+            </tr>
+        </tbody>
+    </table>
 
-
-        <table class="form-group">
-            <tbody>
-                <tr>
-                    <td>@messages("pages.frs.confirmBusinessSector.table.row1.heading")</td>
-                    <td>@Html(businessSectorView.businessSector)</td>
-                </tr>
-                <tr>
-                    <td>@messages("pages.frs.confirmBusinessSector.table.row2.heading")</td>
-                    <td>@Html(businessSectorView.flatRatePercentageFormatted)</td>
-                </tr>
-            </tbody>
-        </table>
-
-        <div class="form-group">
-            <div class="panel indent">
-                <p>@messages("pages.frs.confirmBusinessSector.panel1.para")</p>
-            </div>
+    <div class="form-group">
+        <div class="panel indent">
+            <p>@messages("pages.frs.confirmBusinessSector.panel1.para")</p>
         </div>
-
-        <div class="form-group notice">
-            <i class="icon icon-important">
-                <span class="hidden">Warning</span>
-            </i>
-            <strong class="bold-small">
-                @messages("pages.frs.confirmBusinessSector.exclamationPoint")
-            </strong>
-        </div>
-
-        <div class="form-group">
-            <a href="#">@messages("pages.frs.confirmBusinessSector.changeLink")</a>
-        </div>
-
-        @govHelpers.form(action = controllers.frs.routes.ConfirmBusinessSectorController.submit()) {
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
     </div>
 
+    <div class="form-group notice">
+        <i class="icon icon-important">
+            <span class="hidden">Warning</span>
+        </i>
+        <strong class="bold-small">
+            @messages("pages.frs.confirmBusinessSector.exclamationPoint")
+        </strong>
+    </div>
+
+    <div class="form-group">
+        <a href="#">@messages("pages.frs.confirmBusinessSector.changeLink")</a>
+    </div>
+
+    @govHelpers.form(action = controllers.frs.routes.ConfirmBusinessSectorController.submit()) {
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }

--- a/app/features/frs/views/frs_join.scala.html
+++ b/app/features/frs/views/frs_join.scala.html
@@ -5,51 +5,47 @@
 
 @main_template(title = messages("pages.frs.join.title")) {
 
-    <div class="column-two-thirds">
-        @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            joinFrsForm
-        )
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.join.heading")</h1>
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        joinFrsForm
+    )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.join.heading")</h1>
 
-        <h3>@messages("pages.frs.join.subheading1")</h3>
-        <ul class="list list-bullet">
-            <li>@messages("pages.frs.join.list1.bullet1")</li>
-            <li>@messages("pages.frs.join.list1.bullet2")</li>
-        </ul>
+    <h3>@messages("pages.frs.join.subheading1")</h3>
+    <ul class="list list-bullet">
+        <li>@messages("pages.frs.join.list1.bullet1")</li>
+        <li>@messages("pages.frs.join.list1.bullet2")</li>
+    </ul>
 
-        <h3>@messages("pages.frs.join.subheading2")</h3>
-        <ul class="list list-bullet">
-            <li>@messages("pages.frs.join.list2.bullet1")</li>
-            <li>@messages("pages.frs.join.list2.bullet2")</li>
-        </ul>
+    <h3>@messages("pages.frs.join.subheading2")</h3>
+    <ul class="list list-bullet">
+        <li>@messages("pages.frs.join.list2.bullet1")</li>
+        <li>@messages("pages.frs.join.list2.bullet2")</li>
+    </ul>
 
 
-        <p>@Html(messages("pages.frs.join.para1"))</p>
-        <p>@Html(messages("pages.frs.join.para2"))</p>
+    <p>@Html(messages("pages.frs.join.para1"))</p>
+    <p>@Html(messages("pages.frs.join.para2"))</p>
 
-        @govHelpers.form(action = controllers.frs.routes.JoinFrsController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="joinFrsRadio"></span>
-                    @vatInputRadioGroup(
-                        field = joinFrsForm("joinFrsRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+    @govHelpers.form(action = controllers.frs.routes.JoinFrsController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="joinFrsRadio"></span>
+                @vatInputRadioGroup(
+                    field = joinFrsForm("joinFrsRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/frs/views/frs_register_for.scala.html
+++ b/app/features/frs/views/frs_register_for.scala.html
@@ -5,49 +5,44 @@
 
 @main_template(title = messages("pages.frs.registerFor.title")) {
 
-    <div class="column-two-thirds">
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        registerForFrsForm
+    )
 
-        @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            registerForFrsForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.registerFor.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.registerFor.heading")</h1>
+    <p>@messages("pages.frs.registerFor.p")</p>
 
-        <p>@messages("pages.frs.registerFor.p")</p>
-
-        <div class="form-group">
-            <div class="panel indent">
-                <p>@messages("pages.frs.registerFor.panel1.para")</p>
-            </div>
+    <div class="form-group">
+        <div class="panel indent">
+            <p>@messages("pages.frs.registerFor.panel1.para")</p>
         </div>
-
-        <h3>@messages("pages.frs.registerFor.subheading1")</h3>
-
-        @govHelpers.form(action = controllers.frs.routes.RegisterForFrsController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="registerForFrsRadio"></span>
-                    @vatInputRadioGroup(
-                        field = registerForFrsForm("registerForFrsRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label",
-                        '_legend -> messages("pages.frs.registerFor.subheading1"),
-                        '_legendClass -> "hidden"
-                    )
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
     </div>
 
+    <h3>@messages("pages.frs.registerFor.subheading1")</h3>
+
+    @govHelpers.form(action = controllers.frs.routes.RegisterForFrsController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="registerForFrsRadio"></span>
+                @vatInputRadioGroup(
+                    field = registerForFrsForm("registerForFrsRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label",
+                    '_legend -> messages("pages.frs.registerFor.subheading1"),
+                    '_legendClass -> "hidden"
+                )
+            </fieldset>
+        </div>
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/features/frs/views/frs_start_date.scala.html
+++ b/app/features/frs/views/frs_start_date.scala.html
@@ -7,96 +7,89 @@
 
 @main_template(title = messages("pages.frs.startDate.title")) {
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+    @errorSummary(
+       Messages("app.common.errorSummaryLabel"),
+       frsStartDateForm
+    )
 
-       @errorSummary(
-           Messages("app.common.errorSummaryLabel"),
-           frsStartDateForm
-       )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.startDate.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.startDate.heading")</h1>
+    @govHelpers.form(action = controllers.frs.routes.FrsStartDateController.submit()) {
+        <div class="form-group">
 
-        @govHelpers.form(action = controllers.frs.routes.FrsStartDateController.submit()) {
-            <div class="form-group">
+            @defining(DateTimeFormatter
+                    .ofLocalizedDate(java.time.format.FormatStyle.LONG)
+                    .withLocale(java.util.Locale.UK)) { formatter =>
 
-                @defining(DateTimeFormatter
-                        .ofLocalizedDate(java.time.format.FormatStyle.LONG)
-                        .withLocale(java.util.Locale.UK)) { formatter =>
+                    @vatInputRadioGroup(
+                        frsStartDateForm("frsStartDateRadio"),
+                        Seq(
+                            Some(FrsStartDateView.VAT_REGISTRATION_DATE -> Messages("pages.frs.startDate.radio1")),
+                            Some(FrsStartDateView.DIFFERENT_DATE -> Messages("pages.frs.startDate.radio2"))
+                        ).flatten,
+                        '_labelAfter -> true,
+                        '_labelClass -> "block-label",
+                        '_legend -> ""
+                    )
+                }
 
-                        @vatInputRadioGroup(
-                            frsStartDateForm("frsStartDateRadio"),
-                            Seq(
-                                Some(FrsStartDateView.VAT_REGISTRATION_DATE -> Messages("pages.frs.startDate.radio1")),
-                                Some(FrsStartDateView.DIFFERENT_DATE -> Messages("pages.frs.startDate.radio2"))
-                            ).flatten,
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label",
-                            '_legend -> ""
-                        )
+                <div class="panel panel-indent hidden" id="different_date_panel">
+                    <p>@messages("pages.frs.startDate.para1")</p>
+
+                    <span class="form-hint">@messages("pages.frs.startDate.hint1")</span>
+
+
+                    @defining(frsStartDateForm("frsStartDate").errors.nonEmpty) { errorPresent =>
+                        <div class="form-date @if(errorPresent) { form-group-error }">
+
+                            <fieldset id="frs-start-date">
+                                <legend></legend>
+                                <label><span class="hidden">Frs Start date input</span>
+                                @frsStartDateForm.error("frsStartDate").map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                    @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                    <input type="hidden" name="frsStartDate" value="" id="frsStartDate" class="hidden" />
+                                </label>
+
+                                @vatInput(
+                                    frsStartDateForm("frsStartDate.day"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.frs.startDate.day"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    frsStartDateForm("frsStartDate.month"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.frs.startDate.month"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    frsStartDateForm("frsStartDate.year"),
+                                    '_divClass -> "form-group form-group-year",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 4,
+                                    '_label -> Messages("pages.frs.startDate.year"),
+                                    '_labelClass -> "form-label"
+                                )
+                            </fieldset>
+                        </div>
                     }
+                </div>
+        </div>
 
-                    <div class="panel panel-indent hidden" id="different_date_panel">
-                        <p>@messages("pages.frs.startDate.para1")</p>
-
-                        <span class="form-hint">@messages("pages.frs.startDate.hint1")</span>
-
-
-                        @defining(frsStartDateForm("frsStartDate").errors.nonEmpty) { errorPresent =>
-                            <div class="form-date @if(errorPresent) { form-group-error }">
-
-                                <fieldset id="frs-start-date">
-                                    <legend></legend>
-                                    <label><span class="hidden">Frs Start date input</span>
-                                    @frsStartDateForm.error("frsStartDate").map { error =>
-                                        <span class="error-notification" role="tooltip">
-                                            @messages(error.message, error.args: _*)
-                                        </span>
-                                    }
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="hidden" name="frsStartDate" value="" id="frsStartDate" class="hidden" />
-                                    </label>
-
-                                    @vatInput(
-                                        frsStartDateForm("frsStartDate.day"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.frs.startDate.day"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        frsStartDateForm("frsStartDate.month"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.frs.startDate.month"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        frsStartDateForm("frsStartDate.year"),
-                                        '_divClass -> "form-group form-group-year",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 4,
-                                        '_label -> Messages("pages.frs.startDate.year"),
-                                        '_labelClass -> "form-label"
-                                    )
-                                </fieldset>
-                            </div>
-                        }
-                    </div>
-            </div>
-
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-  </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/frs/views/frs_your_flat_rate.scala.html
+++ b/app/features/frs/views/frs_your_flat_rate.scala.html
@@ -6,60 +6,55 @@
 
 @main_template(title = messages("pages.frs.registerForWithSector.title")) {
 
-    <div class="column-two-thirds">
+    @errorSummary(
+        Messages("app.common.errorSummaryLabel"),
+        registerForFrsForm
+    )
 
-        @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            registerForFrsForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.registerForWithSector.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.frs.registerForWithSector.heading")</h1>
+    <table class="form-group">
+        <tbody>
+            <tr>
+                <td>@messages("pages.frs.registerForWithSector.table.row1.heading")</td>
+                <td>@Html(businessSectorView.businessSector)</td>
+            </tr>
+            <tr>
+                <td>@messages("pages.frs.registerForWithSector.table.row2.heading")</td>
+                <td>@Html(businessSectorView.flatRatePercentageFormatted)</td>
+            </tr>
+        </tbody>
+    </table>
 
-        <table class="form-group">
-            <tbody>
-                <tr>
-                    <td>@messages("pages.frs.registerForWithSector.table.row1.heading")</td>
-                    <td>@Html(businessSectorView.businessSector)</td>
-                </tr>
-                <tr>
-                    <td>@messages("pages.frs.registerForWithSector.table.row2.heading")</td>
-                    <td>@Html(businessSectorView.flatRatePercentageFormatted)</td>
-                </tr>
-            </tbody>
-        </table>
-
-        <div class="form-group">
-            <div class="panel indent">
-                <p>@messages("pages.frs.registerForWithSector.panel1.para")</p>
-            </div>
+    <div class="form-group">
+        <div class="panel indent">
+            <p>@messages("pages.frs.registerForWithSector.panel1.para")</p>
         </div>
-
-        <h3>@messages("pages.frs.registerForWithSector.subheading1")</h3>
-
-        @govHelpers.form(action = controllers.frs.routes.RegisterForFrsWithSectorController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="registerForFrsWithSectorRadio"></span>
-                    @vatInputRadioGroup(
-                        field = registerForFrsForm("registerForFrsWithSectorRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label",
-                        '_legend -> messages("pages.frs.registerForWithSector.subheading1"),
-                        '_legendClass -> "hidden"
-                    )
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
     </div>
 
+    <h3>@messages("pages.frs.registerForWithSector.subheading1")</h3>
+
+    @govHelpers.form(action = controllers.frs.routes.RegisterForFrsWithSectorController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="registerForFrsWithSectorRadio"></span>
+                @vatInputRadioGroup(
+                    field = registerForFrsForm("registerForFrsWithSectorRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label",
+                    '_legend -> messages("pages.frs.registerForWithSector.subheading1"),
+                    '_legendClass -> "hidden"
+                )
+            </fieldset>
+        </div>
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/features/officers/views/completion_capacity.scala.html
+++ b/app/features/officers/views/completion_capacity.scala.html
@@ -6,48 +6,43 @@
 
 @main_template(title = messages("pages.completionCapacity.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+    messages("app.common.errorSummaryLabel"),
+    completionCapacityForm
+    )
 
-        @errorSummary(
-        messages("app.common.errorSummaryLabel"),
-        completionCapacityForm
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.completionCapacity.heading")</h1>
+    </header>
+
+    <p>@messages("pages.completionCapacity.p1")</p>
+
+    <details role="group">
+        <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+            <span class="summary">@messages("pages.completionCapacity.panel.title")</span>
+        </summary>
+        <div class="panel panel-indent" id="details-content-0" aria-hidden="true">
+            <p>@Html(messages("pages.completionCapacity.panel.p1"))</p>
+            <p>@Html(messages("pages.completionCapacity.panel.p2"))</p>
+        </div>
+    </details>
+
+    @govHelpers.form(action = controllers.vatLodgingOfficer.routes.CompletionCapacityController.submit()) {
+        <div class="form-group" id="completionCapacityRadio">
+
+        @vatInputRadioGroup(
+            field = completionCapacityForm("completionCapacityRadio"),
+            officerList.map(officer => (officer.name.id, officer.name.asLabel)),
+            '_labelAfter -> true,
+            '_legend -> messages("pages.completionCapacity.heading"),
+            '_legendClass -> "hidden",
+            '_labelClass -> "block-label"
         )
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.completionCapacity.heading")</h1>
-        </header>
+        </div>
 
-        <p>@messages("pages.completionCapacity.p1")</p>
-
-        <details role="group">
-            <summary role="button" aria-controls="details-content-0" aria-expanded="false">
-                <span class="summary">@messages("pages.completionCapacity.panel.title")</span>
-            </summary>
-            <div class="panel panel-indent" id="details-content-0" aria-hidden="true">
-                <p>@Html(messages("pages.completionCapacity.panel.p1"))</p>
-                <p>@Html(messages("pages.completionCapacity.panel.p2"))</p>
-            </div>
-        </details>
-
-        @govHelpers.form(action = controllers.vatLodgingOfficer.routes.CompletionCapacityController.submit()) {
-            <div class="form-group" id="completionCapacityRadio">
-
-            @vatInputRadioGroup(
-                field = completionCapacityForm("completionCapacityRadio"),
-                officerList.map(officer => (officer.name.id, officer.name.asLabel)),
-                '_labelAfter -> true,
-                '_legend -> messages("pages.completionCapacity.heading"),
-                '_legendClass -> "hidden",
-                '_labelClass -> "block-label"
-            )
-
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }

--- a/app/features/officers/views/former_name.scala.html
+++ b/app/features/officers/views/former_name.scala.html
@@ -8,58 +8,51 @@
 
 @main_template(title = messages("pages.formerName.title")) {
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    formerNameForm,
+    Seq("formerName")
+    )
 
-            @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            formerNameForm,
-            Seq("formerName")
-            )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.formerName.heading")</h1>
 
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.formerName.heading")</h1>
+    @govHelpers.form(action = controllers.vatLodgingOfficer.routes.FormerNameController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="formerNameRadio"/>
+                @vatInputRadioGroup(
+                    field = formerNameForm("formerNameRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
 
-            @govHelpers.form(action = controllers.vatLodgingOfficer.routes.FormerNameController.submit()) {
-                <div class="form-group">
-                    <fieldset class="inline">
-                        <span id="formerNameRadio"/>
-                        @vatInputRadioGroup(
-                            field = formerNameForm("formerNameRadio"),
-                            Seq(
-                                "true" -> Messages("app.common.yes"),
-                                "false" -> Messages("app.common.no")
-                            ),
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label"
-                        )
+                <div class="panel panel-indent hidden @fieldSetClasses" id="former_name_panel">
 
-                        <div class="panel panel-indent hidden @fieldSetClasses" id="former_name_panel">
+                    @formerNameForm.errors.find(_.args.contains("formerName")).map { error =>
+                        @govHelpers.errorInline("formerName", Messages(error.message))
+                    }
 
-                            @formerNameForm.errors.find(_.args.contains("formerName")).map { error =>
-                                @govHelpers.errorInline("formerName", Messages(error.message))
-                            }
+                    @vatInput(
+                        formerNameForm("formerName"),
+                        '_divClass -> "form-group",
+                        '_inputClass -> "form-control",
+                        '_label -> Messages("pages.formerName.fullName.label"),
+                        '_inputHint -> Messages("pages.formerName.fullName.hint"),
+                        '_labelClass -> "form-label"
+                    )
 
-                            @vatInput(
-                                formerNameForm("formerName"),
-                                '_divClass -> "form-group",
-                                '_inputClass -> "form-control",
-                                '_label -> Messages("pages.formerName.fullName.label"),
-                                '_inputHint -> Messages("pages.formerName.fullName.hint"),
-                                '_labelClass -> "form-label"
-                            )
-
-                        </div>
-                    </fieldset>
                 </div>
-
-                <div class="form-group">
-                    <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-                </div>
-            }
-
+            </fieldset>
         </div>
-    </div>
 
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/officers/views/former_name_date.scala.html
+++ b/app/features/officers/views/former_name_date.scala.html
@@ -7,81 +7,76 @@
 
 @main_template(title = messages("pages.formerNameDate.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         formerNameDateForm
-        )
+    )
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.formerNameDate.heading1") @formerName@messages("pages.formerNameDate.heading2")</h1>
-        </header>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.formerNameDate.heading1") @formerName@messages("pages.formerNameDate.heading2")</h1>
+    </header>
 
-        @govHelpers.form(action = controllers.vatLodgingOfficer.routes.FormerNameDateController.submit()) {
-            <div class="form-group">
+    @govHelpers.form(action = controllers.vatLodgingOfficer.routes.FormerNameDateController.submit()) {
+        <div class="form-group">
 
-                @defining(DateTimeFormatter
-                        .ofLocalizedDate(java.time.format.FormatStyle.LONG)
-                        .withLocale(java.util.Locale.UK)) { formatter =>
-                        }
+            @defining(DateTimeFormatter
+                    .ofLocalizedDate(java.time.format.FormatStyle.LONG)
+                    .withLocale(java.util.Locale.UK)) { formatter =>
+                    }
 
-                        <span class="form-hint">@messages("pages.formerNameDate.hint1")</span>
+                    <span class="form-hint">@messages("pages.formerNameDate.hint1")</span>
 
 
-                        @defining(formerNameDateForm("formerNameDate").errors.nonEmpty) { errorPresent =>
-                            <div class="form-date @if(errorPresent) { form-group-error }">
+                    @defining(formerNameDateForm("formerNameDate").errors.nonEmpty) { errorPresent =>
+                        <div class="form-date @if(errorPresent) { form-group-error }">
 
-                                <fieldset id="former-name-date">
-                                    <legend></legend>
-                                    <label><span class="hidden">Former name date change</span>
-                                    @formerNameDateForm.error("formerNameDate").map { error =>
-                                        <span class="error-notification" role="tooltip">
-                                            @messages(error.message, error.args: _*)
-                                        </span>
-                                    }
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="hidden" name="formerNameDate" value="" id="formerNameDate" class="hidden" />
-                                    </label>
+                            <fieldset id="former-name-date">
+                                <legend></legend>
+                                <label><span class="hidden">Former name date change</span>
+                                @formerNameDateForm.error("formerNameDate").map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                    @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                    <input type="hidden" name="formerNameDate" value="" id="formerNameDate" class="hidden" />
+                                </label>
 
-                                    @vatInput(
-                                        formerNameDateForm("formerNameDate.day"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("validation.formerNameDate.day.invalid"),
-                                        '_labelClass -> "form-label"
-                                    )
+                                @vatInput(
+                                    formerNameDateForm("formerNameDate.day"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("validation.formerNameDate.day.invalid"),
+                                    '_labelClass -> "form-label"
+                                )
 
-                                    @vatInput(
-                                        formerNameDateForm("formerNameDate.month"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("validation.formerNameDate.month.invalid"),
-                                        '_labelClass -> "form-label"
-                                    )
+                                @vatInput(
+                                    formerNameDateForm("formerNameDate.month"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("validation.formerNameDate.month.invalid"),
+                                    '_labelClass -> "form-label"
+                                )
 
-                                    @vatInput(
-                                        formerNameDateForm("formerNameDate.year"),
-                                        '_divClass -> "form-group form-group-year",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 4,
-                                        '_label -> Messages("validation.formerNameDate.year.invalid"),
-                                        '_labelClass -> "form-label"
-                                    )
-                                </fieldset>
-                            </div>
-                        }
-            </div>
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+                                @vatInput(
+                                    formerNameDateForm("formerNameDate.year"),
+                                    '_divClass -> "form-group form-group-year",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 4,
+                                    '_label -> Messages("validation.formerNameDate.year.invalid"),
+                                    '_labelClass -> "form-label"
+                                )
+                            </fieldset>
+                        </div>
+                    }
+        </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/officers/views/officer_contact_details.scala.html
+++ b/app/features/officers/views/officer_contact_details.scala.html
@@ -5,69 +5,63 @@
 
 @main_template(title = messages("pages.officerContact.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+  messages("app.common.errorSummaryLabel"),
+  officerContactDetailsForm
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      officerContactDetailsForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.officerContact.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.officerContact.heading")</h1>
+  <div class="panel panel-indent" id="details-content-0" aria-hidden="true">
+      <p>@Html(messages("pages.officerContact.p1"))</p>
+  </div>
+  <br />
 
-      <div class="panel panel-indent" id="details-content-0" aria-hidden="true">
-          <p>@Html(messages("pages.officerContact.p1"))</p>
+  @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerContactDetailsController.submit()) {
+      <div class="form-group">
+          <fieldset>
+
+              @officerContactDetailsForm.errors.find(_.args.contains("officerContactDetails")).map { error =>
+                  @govHelpers.errorInline("officerContactDetails", messages(error.message))
+              }
+
+              @vatInput(
+                  officerContactDetailsForm("email"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 70,
+                  '_label -> messages("pages.officerContact.emailAddress.label")
+              )
+
+
+              @vatInput(
+                  officerContactDetailsForm("mobile"),
+                  '_type -> "text",
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 20,
+                  '_label -> messages("pages.officerContact.mobile.label")
+              )
+
+              @vatInput(
+                  officerContactDetailsForm("daytimePhone"),
+                  '_type -> "text",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 20,
+                  '_label -> messages("pages.officerContact.daytimePhone.label")
+              )
+
+          </fieldset>
+
       </div>
-      <br />
 
-      @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerContactDetailsController.submit()) {
-          <div class="form-group">
-              <fieldset>
-
-                  @officerContactDetailsForm.errors.find(_.args.contains("officerContactDetails")).map { error =>
-                      @govHelpers.errorInline("officerContactDetails", messages(error.message))
-                  }
-
-                  @vatInput(
-                      officerContactDetailsForm("email"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 70,
-                      '_label -> messages("pages.officerContact.emailAddress.label")
-                  )
-
-
-                  @vatInput(
-                      officerContactDetailsForm("mobile"),
-                      '_type -> "text",
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 20,
-                      '_label -> messages("pages.officerContact.mobile.label")
-                  )
-
-                  @vatInput(
-                      officerContactDetailsForm("daytimePhone"),
-                      '_type -> "text",
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 20,
-                      '_label -> messages("pages.officerContact.daytimePhone.label")
-                  )
-
-              </fieldset>
-
-          </div>
-
-          <div class="form-group">
-              <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-          </div>
-      }
-
-    </div>
-
+      <div class="form-group">
+          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+      </div>
+  }
 }
 
 <script type="text/javascript">

--- a/app/features/officers/views/officer_home_address.scala.html
+++ b/app/features/officers/views/officer_home_address.scala.html
@@ -6,37 +6,31 @@
 
 @main_template(title = messages("pages.officerHomeAddress.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+  messages("app.common.errorSummaryLabel"),
+  officerHomeAddressForm
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      officerHomeAddressForm
-      )
+  <header class="page-header">
+      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.officerHomeAddress.heading")</h1>
+  </header>
 
-      <header class="page-header">
-          <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.officerHomeAddress.heading")</h1>
-      </header>
+  @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerHomeAddressController.submit()) {
+    <div class="form-group" id="homeAddressRadio">
 
-      @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerHomeAddressController.submit()) {
-      <div class="form-group" id="homeAddressRadio">
-
-          @vatInputRadioGroup(
-              field = officerHomeAddressForm("homeAddressRadio"),
-              addresses.map( a => (a.id, a.asLabel)) :+
-                      ("other" -> messages("pages.officerHomeAddress.different.address")),
-              '_legend -> messages("pages.officerHomeAddress.heading"),
-              '_legendClass -> "hidden",
-              '_labelAfter -> true,
-              '_labelClass -> "block-label"
-          )
-
-      </div>
-          <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
+        @vatInputRadioGroup(
+            field = officerHomeAddressForm("homeAddressRadio"),
+            addresses.map( a => (a.id, a.asLabel)) :+
+                    ("other" -> messages("pages.officerHomeAddress.different.address")),
+            '_legend -> messages("pages.officerHomeAddress.heading"),
+            '_legendClass -> "hidden",
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
 
     </div>
-
+    <div class="form-group">
+      <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+    </div>
+  }
 }

--- a/app/features/officers/views/officer_security_questions.scala.html
+++ b/app/features/officers/views/officer_security_questions.scala.html
@@ -5,94 +5,89 @@
 
 @main_template(title = messages("pages.security.questions.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+  messages("app.common.errorSummaryLabel"),
+  securityQuestionsForm
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      securityQuestionsForm
-      )
+  <header class="page-header">
+      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.security.questions.heading")</h1>
+  </header>
 
-      <header class="page-header">
-          <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.security.questions.heading")</h1>
-      </header>
+  <p>@messages("pages.security.questions.p1")</p>
+  <h3 class="form-title heading-medium">@messages("pages.security.questions.date.of.birth.h3")</h3>
 
-      <p>@messages("pages.security.questions.p1")</p>
-      <h3 class="form-title heading-medium">@messages("pages.security.questions.date.of.birth.h3")</h3>
+  @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerSecurityQuestionsController.submit()) {
+  <div class="form-group-compound">
+      @defining(securityQuestionsForm("dob").errors.nonEmpty) { errorPresent =>
+          <div class="form-date @if(errorPresent) { form-group-error }">
+          <fieldset id="dob">
+              <label><span class="hidden">DOB input</span>
+                  @securityQuestionsForm.error("dob").map { error =>
+                      <span class="error-notification" role="tooltip">
+                          @messages(error.message, error.args: _*)
+                      </span>
+                  }
+              </label>
+              <span class="form-hint">@messages("pages.security.questions.date.of.birth.hint")</span>
 
-      @govHelpers.form(action = controllers.vatLodgingOfficer.routes.OfficerSecurityQuestionsController.submit()) {
-      <div class="form-group-compound">
-          @defining(securityQuestionsForm("dob").errors.nonEmpty) { errorPresent =>
-              <div class="form-date @if(errorPresent) { form-group-error }">
-              <fieldset id="dob">
-                  <label><span class="hidden">DOB input</span>
-                      @securityQuestionsForm.error("dob").map { error =>
-                          <span class="error-notification" role="tooltip">
-                              @messages(error.message, error.args: _*)
-                          </span>
-                      }
-                  </label>
-                  <span class="form-hint">@messages("pages.security.questions.date.of.birth.hint")</span>
+              @vatInput(
+                  securityQuestionsForm("dob.day"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_maxlength -> 2,
+                  '_label -> messages("pages.security.questions.day.label"),
+                  '_labelClass -> "form-label"
+              )
 
-                  @vatInput(
-                      securityQuestionsForm("dob.day"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_maxlength -> 2,
-                      '_label -> messages("pages.security.questions.day.label"),
-                      '_labelClass -> "form-label"
-                  )
+              @vatInput(
+                  securityQuestionsForm("dob.month"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_maxlength -> 2,
+                  '_label -> messages("pages.security.questions.month.label"),
+                  '_labelClass -> "form-label"
+              )
 
-                  @vatInput(
-                      securityQuestionsForm("dob.month"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_maxlength -> 2,
-                      '_label -> messages("pages.security.questions.month.label"),
-                      '_labelClass -> "form-label"
-                  )
+              @vatInput(
+                  securityQuestionsForm("dob.year"),
+                  '_divClass -> "form-group form-group-year",
+                  '_inputClass -> "form-control",
+                  '_maxlength -> 4,
+                  '_label -> messages("pages.security.questions.year.label"),
+                  '_labelClass -> "form-label"
+              )
+              @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+              <input type="hidden" name="dob" value="" id="dob" class="hidden" />
+          </fieldset>
+          </div>
 
-                  @vatInput(
-                      securityQuestionsForm("dob.year"),
-                      '_divClass -> "form-group form-group-year",
-                      '_inputClass -> "form-control",
-                      '_maxlength -> 4,
-                      '_label -> messages("pages.security.questions.year.label"),
-                      '_labelClass -> "form-label"
-                  )
-                  @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                  <input type="hidden" name="dob" value="" id="dob" class="hidden" />
-              </fieldset>
-              </div>
-
-              <h3 class="form-title heading-medium">@messages("pages.security.questions.nino.h3")</h3>
-                  <p>@messages("pages.security.questions.nino.p1")</p>
-
-                  <fieldset id="nino">
-                  <legend></legend>
-                  <span class="form-hint">@messages("pages.security.questions.nino.hint")</span>
-                  @vatInput(
-                      securityQuestionsForm("nino"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_minlength -> 13,
-                      '_maxlength -> 13,
-                      '_label -> messages("pages.security.questions.nino.h3"),
-                      '_labelTextClass -> "hidden",
-                      '_labelClass -> "form-label"
-                  )
-
-              </fieldset>                 
-                  
-      }
-      </div>
+          <h3 class="form-title heading-medium">@messages("pages.security.questions.nino.h3")</h3>
+          <p>@messages("pages.security.questions.nino.p1")</p>
           <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
+            <fieldset id="nino">
+              <legend></legend>
+              <span class="form-hint">@messages("pages.security.questions.nino.hint")</span>
+              @vatInput(
+                  securityQuestionsForm("nino"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_minlength -> 13,
+                  '_maxlength -> 13,
+                  '_label -> messages("pages.security.questions.nino.h3"),
+                  '_labelTextClass -> "hidden",
+                  '_labelClass -> "form-label"
+              )
+            </fieldset>
+          </div>
+              
+  }
+  </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      }
-
-    </div>
-
+  }
 }
 
 <script type="text/javascript">

--- a/app/features/officers/views/previous_address.scala.html
+++ b/app/features/officers/views/previous_address.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.previousAddressQuestion.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+    messages("app.common.errorSummaryLabel"),
+    previousAddressQuestionForm
+    )
 
-        @errorSummary(
-        messages("app.common.errorSummaryLabel"),
-        previousAddressQuestionForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.previousAddressQuestion.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.previousAddressQuestion.heading")</h1>
-        
-        @govHelpers.form(action = controllers.vatLodgingOfficer.routes.PreviousAddressController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="previousAddressQuestionRadio"/>
+    @govHelpers.form(action = controllers.vatLodgingOfficer.routes.PreviousAddressController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="previousAddressQuestionRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = previousAddressQuestionForm("previousAddressQuestionRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = previousAddressQuestionForm("previousAddressQuestionRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/business_activity_description.scala.html
+++ b/app/features/sicAndCompliance/views/business_activity_description.scala.html
@@ -4,44 +4,36 @@
 @import views.html.helpers.templates.{vatTextArea, errorSummary}
 
 @main_template(title = messages("pages.business.activity.description.title")) {
-    <div class="grid-row">
 
-    <div class="column-two-thirds">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    businessActivityDescriptionForm,
+    Seq("description")
+  )
 
-        @errorSummary(
-        Messages("app.common.errorSummaryLabel"),
-        businessActivityDescriptionForm,
-        Seq("description")
-        )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.business.activity.description.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.business.activity.description.heading")</h1>
+  <p>@Html(Messages("pages.business.activity.description.para1"))</p>
 
-      <p>@Html(Messages("pages.business.activity.description.para1"))</p>
+  @govHelpers.form(action = controllers.sicAndCompliance.routes.BusinessActivityDescriptionController.submit()) {
+      <div class="form-group">
+          <fieldset>
+            <style>
+                textarea { height: 5em }
+                label.form-hint p { margin-bottom: 0 }
+            </style>
+            @vatTextArea(
+                    businessActivityDescriptionForm("description"),
+                    '_divClass -> "form-group",
+                    '_labelClass -> "form-label",
+                    '_inputClass -> "form-control fill-width",
+                    '_label -> messages("pages.business.activity.description.label")
+            )
+          </fieldset>
+      </div>
 
-      @govHelpers.form(action = controllers.sicAndCompliance.routes.BusinessActivityDescriptionController.submit()) {
-          <div class="form-group">
-              <fieldset>
-                  <style>
-                      textarea { height: 5em }
-                      label.form-hint p { margin-bottom: 0 }
-                  </style>
-                  @vatTextArea(
-                          businessActivityDescriptionForm("description"),
-                          '_divClass -> "form-group",
-                          '_labelClass -> "form-label",
-                          '_inputClass -> "form-control fill-width",
-                          '_label -> messages("pages.business.activity.description.label")
-              )
-
-              </fieldset>
-
-          </div>
-
-          <div class="form-group">
-              <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-          </div>
-      }
-
-    </div>
-</div>
+      <div class="form-group">
+          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+      </div>
+  }
 }

--- a/app/features/sicAndCompliance/views/compliance_introduction.scala.html
+++ b/app/features/sicAndCompliance/views/compliance_introduction.scala.html
@@ -4,25 +4,17 @@
 
 @main_template(title = messages("pages.compliance.introduction.title")) {
 
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.compliance.introduction.heading")</h1>
+    </header>
 
-<div class="grid-row">
-    <div class="column-one-third">
+    <p>@messages("pages.compliance.introduction.para1")</p>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.compliance.introduction.heading")</h1>
-        </header>
+    <br />
 
-        <p>@messages("pages.compliance.introduction.para1")</p>
-
-        <br />
-
-        @form(action = controllers.sicAndCompliance.routes.ComplianceIntroductionController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" type="submit" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
-
-    </div>
-
-</div>
+    @form(action = controllers.sicAndCompliance.routes.ComplianceIntroductionController.submit()) {
+        <div class="form-group">
+            <button class="button-get-started" type="submit" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/features/sicAndCompliance/views/cultural/not_for_profit.scala.html
+++ b/app/features/sicAndCompliance/views/cultural/not_for_profit.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.culturalCompliance.notForProfit.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         notForProfitForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.culturalCompliance.notForProfit.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.culturalCompliance.notForProfit.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.cultural.routes.NotForProfitController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="notForProfitRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.cultural.routes.NotForProfitController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="notForProfitRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = notForProfitForm("notForProfitRadio"),
-                        Seq(
-                            NotForProfit.NOT_PROFIT_YES -> Messages("app.common.yes"),
-                            NotForProfit.NOT_PROFIT_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = notForProfitForm("notForProfitRadio"),
+                    Seq(
+                        NotForProfit.NOT_PROFIT_YES -> Messages("app.common.yes"),
+                        NotForProfit.NOT_PROFIT_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/act_as_intermediary.scala.html
+++ b/app/features/sicAndCompliance/views/financial/act_as_intermediary.scala.html
@@ -5,42 +5,37 @@
 
 @main_template(title = messages("pages.financialCompliance.actAsIntermediary.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         actAsIntermediaryForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.actAsIntermediary.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.actAsIntermediary.heading")</h1>
 
-        <p>
-        @messages("pages.financialCompliance.actAsIntermediary.para")
-        </p>
+    <p>
+    @messages("pages.financialCompliance.actAsIntermediary.para")
+    </p>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ActAsIntermediaryController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="actAsIntermediaryRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ActAsIntermediaryController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="actAsIntermediaryRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = actAsIntermediaryForm("actAsIntermediaryRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = actAsIntermediaryForm("actAsIntermediaryRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/additional_non_securities_work.scala.html
+++ b/app/features/sicAndCompliance/views/financial/additional_non_securities_work.scala.html
@@ -5,42 +5,37 @@
 
 @main_template(title = messages("pages.financialCompliance.additionalNonSecuritiesWork.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    additionalNonSecuritiesWorkForm
+    )
 
-        @errorSummary(
-        Messages("app.common.errorSummaryLabel"),
-        additionalNonSecuritiesWorkForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.additionalNonSecuritiesWork.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.additionalNonSecuritiesWork.heading")</h1>
+    <p>
+    @messages("pages.financialCompliance.additionalNonSecuritiesWork.para")
+    </p>
 
-        <p>
-        @messages("pages.financialCompliance.additionalNonSecuritiesWork.para")
-        </p>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.AdditionalNonSecuritiesWorkController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="additionalNonSecuritiesWorkRadio"/>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.AdditionalNonSecuritiesWorkController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="additionalNonSecuritiesWorkRadio"/>
+                @vatInputRadioGroup(
+                    field = additionalNonSecuritiesWorkForm("additionalNonSecuritiesWorkRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-                    @vatInputRadioGroup(
-                        field = additionalNonSecuritiesWorkForm("additionalNonSecuritiesWorkRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/advice_or_consultancy.scala.html
+++ b/app/features/sicAndCompliance/views/financial/advice_or_consultancy.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.financialCompliance.adviceOrConsultancy.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         adviceOrConsultancyForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.adviceOrConsultancy.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.adviceOrConsultancy.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.AdviceOrConsultancyController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="adviceOrConsultancyRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.AdviceOrConsultancyController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="adviceOrConsultancyRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = adviceOrConsultancyForm("adviceOrConsultancyRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = adviceOrConsultancyForm("adviceOrConsultancyRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/charge_fees.scala.html
+++ b/app/features/sicAndCompliance/views/financial/charge_fees.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.financialCompliance.chargeFees.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         chargeFeesForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.chargeFees.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.chargeFees.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ChargeFeesController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="chargeFeesRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ChargeFeesController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="chargeFeesRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = chargeFeesForm("chargeFeesRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = chargeFeesForm("chargeFeesRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/discretionary_investment_management_services.scala.html
+++ b/app/features/sicAndCompliance/views/financial/discretionary_investment_management_services.scala.html
@@ -5,42 +5,37 @@
 
 @main_template(title = messages("pages.financialCompliance.discretionaryInvestmentManagementServices.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         discretionaryInvestmentManagementServicesForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.discretionaryInvestmentManagementServices.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.discretionaryInvestmentManagementServices.heading")</h1>
 
-        <p>
-        @messages("pages.financialCompliance.discretionaryInvestmentManagementServices.para")
-        </p>
+    <p>
+    @messages("pages.financialCompliance.discretionaryInvestmentManagementServices.para")
+    </p>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.DiscretionaryInvestmentManagementServicesController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="discretionaryInvestmentManagementServicesRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.DiscretionaryInvestmentManagementServicesController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="discretionaryInvestmentManagementServicesRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = discretionaryInvestmentManagementServicesForm("discretionaryInvestmentManagementServicesRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = discretionaryInvestmentManagementServicesForm("discretionaryInvestmentManagementServicesRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/investment_fund_management.scala.html
+++ b/app/features/sicAndCompliance/views/financial/investment_fund_management.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.financialCompliance.investmentFundManagement.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         investmentFundManagementForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.investmentFundManagement.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.investmentFundManagement.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.InvestmentFundManagementController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="investmentFundManagementRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.InvestmentFundManagementController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="investmentFundManagementRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = investmentFundManagementForm("investmentFundManagementRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = investmentFundManagementForm("investmentFundManagementRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/lease_vehicles.scala.html
+++ b/app/features/sicAndCompliance/views/financial/lease_vehicles.scala.html
@@ -5,42 +5,37 @@
 
 @main_template(title = messages("pages.financialCompliance.leaseVehicles.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         leaseVehiclesForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.leaseVehicles.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.leaseVehicles.heading")</h1>
 
-        <p>
-        @messages("pages.financialCompliance.leaseVehicles.para")
-        </p>
+    <p>
+    @messages("pages.financialCompliance.leaseVehicles.para")
+    </p>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.LeaseVehiclesController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="leaseVehiclesRadio"></span>
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.LeaseVehiclesController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="leaseVehiclesRadio"></span>
 
-                    @vatInputRadioGroup(
-                        field = leaseVehiclesForm("leaseVehiclesRadio"),
-                        Seq(
-                            "true" -> Messages("app.common.yes"),
-                            "false" -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = leaseVehiclesForm("leaseVehiclesRadio"),
+                    Seq(
+                        "true" -> Messages("app.common.yes"),
+                        "false" -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/financial/manage_additional_funds.scala.html
+++ b/app/features/sicAndCompliance/views/financial/manage_additional_funds.scala.html
@@ -5,53 +5,48 @@
 
 @main_template(title = messages("pages.financialCompliance.manageAdditionalFunds.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         manageAdditionalFundsForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.manageAdditionalFunds.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.financialCompliance.manageAdditionalFunds.heading")</h1>
 
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet1")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet2")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet3")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet4")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet5")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet6")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet7")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet8")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet9")</li>
-                <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet10")</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ManageAdditionalFundsController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="manageAdditionalFundsRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = manageAdditionalFundsForm("manageAdditionalFundsRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet1")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet2")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet3")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet4")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet5")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet6")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet7")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet8")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet9")</li>
+            <li>@messages("pages.financialCompliance.manageAdditionalFunds.bullet10")</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.sicAndCompliance.financial.routes.ManageAdditionalFundsController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="manageAdditionalFundsRadio"/>
+
+                @vatInputRadioGroup(
+                    field = manageAdditionalFundsForm("manageAdditionalFundsRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+
+    }
 }

--- a/app/features/sicAndCompliance/views/labour/company_provide_workers.scala.html
+++ b/app/features/sicAndCompliance/views/labour/company_provide_workers.scala.html
@@ -5,41 +5,36 @@
 
 @main_template(title = messages("pages.labourCompliance.companyProvideWorkers.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         companyProvideWorkersForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.companyProvideWorkers.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.companyProvideWorkers.heading")</h1>
 
-        <p>
-        @messages("pages.labourCompliance.companyProvideWorkers.para")
-        </p>
-        @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.CompanyProvideWorkersController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="companyProvideWorkersRadio"/>
+    <p>
+    @messages("pages.labourCompliance.companyProvideWorkers.para")
+    </p>
+    @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.CompanyProvideWorkersController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="companyProvideWorkersRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = companyProvideWorkersForm("companyProvideWorkersRadio"),
-                        Seq(
-                            CompanyProvideWorkers.PROVIDE_WORKERS_YES -> Messages("app.common.yes"),
-                            CompanyProvideWorkers.PROVIDE_WORKERS_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = companyProvideWorkersForm("companyProvideWorkersRadio"),
+                    Seq(
+                        CompanyProvideWorkers.PROVIDE_WORKERS_YES -> Messages("app.common.yes"),
+                        CompanyProvideWorkers.PROVIDE_WORKERS_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/labour/skilled_workers.scala.html
+++ b/app/features/sicAndCompliance/views/labour/skilled_workers.scala.html
@@ -5,41 +5,34 @@
 
 @main_template(title = messages("pages.labourCompliance.skilledWorkers.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         skilledWorkersForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.skilledWorkers.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.skilledWorkers.heading")</h1>
 
-        <p>
-        @messages("pages.labourCompliance.skilledWorkers.para")
-        </p>
-        @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.SkilledWorkersController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="skilledWorkersRadio"/>
+    <p>@messages("pages.labourCompliance.skilledWorkers.para")</p>
+    @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.SkilledWorkersController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="skilledWorkersRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = skilledWorkersForm("skilledWorkersRadio"),
-                        Seq(
-                            SkilledWorkers.SKILLED_WORKERS_YES -> Messages("app.common.yes"),
-                            SkilledWorkers.SKILLED_WORKERS_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = skilledWorkersForm("skilledWorkersRadio"),
+                    Seq(
+                        SkilledWorkers.SKILLED_WORKERS_YES -> Messages("app.common.yes"),
+                        SkilledWorkers.SKILLED_WORKERS_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/labour/temporary_contracts.scala.html
+++ b/app/features/sicAndCompliance/views/labour/temporary_contracts.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.labourCompliance.temporaryContracts.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         temporaryContractsForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.temporaryContracts.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.temporaryContracts.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.TemporaryContractsController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="temporaryContractsRadio"/>
+    @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.TemporaryContractsController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="temporaryContractsRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = temporaryContractsForm("temporaryContractsRadio"),
-                        Seq(
-                            TemporaryContracts.TEMP_CONTRACTS_YES -> Messages("app.common.yes"),
-                            TemporaryContracts.TEMP_CONTRACTS_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = temporaryContractsForm("temporaryContractsRadio"),
+                    Seq(
+                        TemporaryContracts.TEMP_CONTRACTS_YES -> Messages("app.common.yes"),
+                        TemporaryContracts.TEMP_CONTRACTS_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">Continue</button>
-            </div>
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">Continue</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/sicAndCompliance/views/labour/workers.scala.html
+++ b/app/features/sicAndCompliance/views/labour/workers.scala.html
@@ -8,42 +8,37 @@
 
 @main_template(title = messages("pages.labourCompliance.workers.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         workersForm,
         Seq("numberOfWorkers")
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.workers.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.labourCompliance.workers.heading")</h1>
 
-        @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.WorkersController.submit()) {
-            <div class="form-group @fieldSetClasses">
-                <fieldset>
+    @govHelpers.form(action = controllers.sicAndCompliance.labour.routes.WorkersController.submit()) {
+        <div class="form-group @fieldSetClasses">
+            <fieldset>
 
-                    @workersForm.errors.find(_.args.contains("numberOfWorkers")).map { error =>
-                        @govHelpers.errorInline("numberOfWorkers", Messages(error.message))
-                    }
+                @workersForm.errors.find(_.args.contains("numberOfWorkers")).map { error =>
+                    @govHelpers.errorInline("numberOfWorkers", Messages(error.message))
+                }
 
-                    @vatInput(
-                        workersForm("numberOfWorkers"),
-                        '_divClass -> "form-group",
-                        '_inputClass -> "form-control",
-                        '_label -> Messages("pages.labourCompliance.workers.numberOfWorkers"),
-                        '_labelClass -> "cascading"
-                    )
+                @vatInput(
+                    workersForm("numberOfWorkers"),
+                    '_divClass -> "form-group",
+                    '_inputClass -> "form-control",
+                    '_label -> Messages("pages.labourCompliance.workers.numberOfWorkers"),
+                    '_labelClass -> "cascading"
+                )
 
-                </fieldset>
-            </div>
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">Continue</button>
-            </div>
-        }
-
-    </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">Continue</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/sicAndCompliance/views/main_business_activity.scala.html
+++ b/app/features/sicAndCompliance/views/main_business_activity.scala.html
@@ -6,22 +6,19 @@
 
 @main_template(title = messages("pages.mainBusinessActivity.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+    messages("app.common.errorSummaryLabel"),
+    mainBusinessActivityForm
+    )
 
-        @errorSummary(
-        messages("app.common.errorSummaryLabel"),
-        mainBusinessActivityForm
-        )
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.mainBusinessActivity.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.mainBusinessActivity.heading")</h1>
-        </header>
+    <p>@messages("pages.mainBusinessActivity.para1")</p>
 
-        <p>@messages("pages.mainBusinessActivity.para1")</p>
-
-
-        @govHelpers.form(action = controllers.sicAndCompliance.routes.MainBusinessActivityController.submit()) {
-            <div class="form-group" id="mainBusinessActivityRadio">
+    @govHelpers.form(action = controllers.sicAndCompliance.routes.MainBusinessActivityController.submit()) {
+        <div class="form-group" id="mainBusinessActivityRadio">
 
             @vatInputRadioGroup(
                 field = mainBusinessActivityForm("mainBusinessActivityRadio"),
@@ -32,13 +29,10 @@
                 '_labelClass -> "block-label"
             )
 
-            </div>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }

--- a/app/features/tradingDetails/views/trading_name.scala.html
+++ b/app/features/tradingDetails/views/trading_name.scala.html
@@ -8,57 +8,50 @@
 
 @main_template(title = messages("pages.tradingName.title")) {
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    tradingNameForm,
+    Seq("tradingName")
+    )
 
-            @errorSummary(
-            Messages("app.common.errorSummaryLabel"),
-            tradingNameForm,
-            Seq("tradingName")
-            )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.tradingName.heading")</h1>
 
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.tradingName.heading")</h1>
+    @govHelpers.form(action = controllers.vatTradingDetails.routes.TradingNameController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="tradingNameRadio"/>
+                @vatInputRadioGroup(
+                    field = tradingNameForm("tradingNameRadio"),
+                    Seq(
+                        TradingNameView.TRADING_NAME_YES -> Messages("app.common.yes"),
+                        TradingNameView.TRADING_NAME_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
 
-            @govHelpers.form(action = controllers.vatTradingDetails.routes.TradingNameController.submit()) {
-                <div class="form-group">
-                    <fieldset class="inline">
-                        <span id="tradingNameRadio"/>
-                        @vatInputRadioGroup(
-                            field = tradingNameForm("tradingNameRadio"),
-                            Seq(
-                                TradingNameView.TRADING_NAME_YES -> Messages("app.common.yes"),
-                                TradingNameView.TRADING_NAME_NO -> Messages("app.common.no")
-                            ),
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label"
-                        )
+                <div class="panel panel-indent hidden @fieldSetClasses" id="trading_name_panel">
 
-                        <div class="panel panel-indent hidden @fieldSetClasses" id="trading_name_panel">
+                    @tradingNameForm.errors.find(_.args.contains("tradingName")).map { error =>
+                        @govHelpers.errorInline("tradingName", Messages(error.message))
+                    }
 
-                            @tradingNameForm.errors.find(_.args.contains("tradingName")).map { error =>
-                                @govHelpers.errorInline("tradingName", Messages(error.message))
-                            }
+                    @vatInput(
+                        tradingNameForm("tradingName"),
+                        '_divClass -> "form-group",
+                        '_inputClass -> "form-control",
+                        '_label -> Messages("pages.tradingName.panels.tradingName"),
+                        '_labelClass -> "form-label"
+                    )
 
-                            @vatInput(
-                                tradingNameForm("tradingName"),
-                                '_divClass -> "form-group",
-                                '_inputClass -> "form-control",
-                                '_label -> Messages("pages.tradingName.panels.tradingName"),
-                                '_labelClass -> "form-label"
-                            )
-
-                        </div>
-                    </fieldset>
                 </div>
-
-                <div class="form-group">
-                    <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-                </div>
-            }
-
+            </fieldset>
         </div>
-    </div>
 
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/tradingDetails/views/vatChoice/mandatory_start_date_confirmation.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/mandatory_start_date_confirmation.scala.html
@@ -4,37 +4,28 @@
 
 @main_template(title = messages("pages.start.date.confirmation.title")) {
 
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.start.date.confirmation.heading")</h1>
+    </header>
 
-<div class="grid-row">
-    <div class="column-one-third">
-
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.start.date.confirmation.heading")</h1>
-        </header>
-
-        <p>@messages("pages.start.date.confirmation.para1")</p>
-        <p>@messages("pages.start.date.confirmation.para2")</p>
-        <p>@messages("pages.start.date.confirmation.para3")</p>
+    <p>@messages("pages.start.date.confirmation.para1")</p>
+    <p>@messages("pages.start.date.confirmation.para2")</p>
+    <p>@messages("pages.start.date.confirmation.para3")</p>
 
 
-        <div class="notice form-group">
-            <i class="icon icon-important">
-                <span class="visuallyhidden">Warning</span>
-            </i>
+    <div class="notice form-group">
+        <i class="icon icon-important">
+            <span class="visuallyhidden">Warning</span>
+        </i>
 
-            <strong class="bold-small">@messages("pages.start.date.confirmation.warning")</strong>
-
-        </div>
-
-
-        @form(action = controllers.vatTradingDetails.vatChoice.routes.MandatoryStartDateController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" type="submit" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
-
+        <strong class="bold-small">@messages("pages.start.date.confirmation.warning")</strong>
 
     </div>
 
-</div>
+
+    @form(action = controllers.vatTradingDetails.vatChoice.routes.MandatoryStartDateController.submit()) {
+        <div class="form-group">
+            <button class="button-get-started" type="submit" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/features/tradingDetails/views/vatChoice/over_threshold.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/over_threshold.scala.html
@@ -7,94 +7,87 @@
 
 @main_template(title = messages("pages.thresholdQuestion1.title")) {
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         overThresholdForm
-        )
+    )
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">
-            @messages("pages.thresholdQuestion1.heading", dateOfIncorporation)
-            </h1>
-        </header>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">
+        @messages("pages.thresholdQuestion1.heading", dateOfIncorporation)
+        </h1>
+    </header>
 
-        <p>@messages("pages.thresholdQuestion1.p1")</p>
+    <p>@messages("pages.thresholdQuestion1.p1")</p>
 
-        @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.OverThresholdController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                @defining(DateTimeFormatter
-                        .ofLocalizedDate(java.time.format.FormatStyle.LONG)
-                        .withLocale(java.util.Locale.UK)) { formatter =>
+    @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.OverThresholdController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+            @defining(DateTimeFormatter
+                    .ofLocalizedDate(java.time.format.FormatStyle.LONG)
+                    .withLocale(java.util.Locale.UK)) { formatter =>
 
-                        @vatInputRadioGroup(
-                            overThresholdForm("overThresholdRadio"),
-                            Seq(
-                                "true" -> Messages("app.common.yes"),
-                                "false" -> Messages("app.common.no")
-                            ),
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label",
-                            '_legend -> ""
-                        )
+                    @vatInputRadioGroup(
+                        overThresholdForm("overThresholdRadio"),
+                        Seq(
+                            "true" -> Messages("app.common.yes"),
+                            "false" -> Messages("app.common.no")
+                        ),
+                        '_labelAfter -> true,
+                        '_labelClass -> "block-label",
+                        '_legend -> ""
+                    )
+                }
+
+                <div class="panel panel-indent hidden" id="overThreshold_date_panel">
+                    <h2 class="heading-medium">@messages("pages.thresholdQuestion1.panel.heading")</h2>
+
+                    <span class="form-hint">@messages("pages.thresholdQuestion1.panel.hint")</span>
+
+                    @defining(overThresholdForm("overThreshold").errors.nonEmpty) { errorPresent =>
+                        <div class="form-date @if(errorPresent) { form-field--error }">
+
+                            <fieldset id="over-threshold">
+                                <legend></legend>
+                                <label><span class="hidden">Over Threshold input</span>
+                                @overThresholdForm.error("overThreshold").map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                    @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                    <input type="hidden" name="overThreshold" value="" id="overThreshold" class="hidden" />
+                                </label>
+
+                                @vatInput(
+                                    overThresholdForm("overThreshold.month"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.thresholdQuestion1.month"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    overThresholdForm("overThreshold.year"),
+                                    '_divClass -> "form-group form-group-year",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 4,
+                                    '_label -> Messages("pages.thresholdQuestion1.year"),
+                                    '_labelClass -> "form-label"
+                                )
+                            </fieldset>
+                        </div>
+
                     }
+                </div>
+            </fieldset>
+        </div>
 
-                    <div class="panel panel-indent hidden" id="overThreshold_date_panel">
-                        <h2 class="heading-medium">@messages("pages.thresholdQuestion1.panel.heading")</h2>
-
-                        <span class="form-hint">@messages("pages.thresholdQuestion1.panel.hint")</span>
-
-                        @defining(overThresholdForm("overThreshold").errors.nonEmpty) { errorPresent =>
-                            <div class="form-date @if(errorPresent) { form-field--error }">
-
-                                <fieldset id="over-threshold">
-                                    <legend></legend>
-                                    <label><span class="hidden">Over Threshold input</span>
-                                    @overThresholdForm.error("overThreshold").map { error =>
-                                        <span class="error-notification" role="tooltip">
-                                            @messages(error.message, error.args: _*)
-                                        </span>
-                                    }
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="hidden" name="overThreshold" value="" id="overThreshold" class="hidden" />
-                                    </label>
-
-                                    @vatInput(
-                                        overThresholdForm("overThreshold.month"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.thresholdQuestion1.month"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        overThresholdForm("overThreshold.year"),
-                                        '_divClass -> "form-group form-group-year",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 4,
-                                        '_label -> Messages("pages.thresholdQuestion1.year"),
-                                        '_labelClass -> "form-label"
-                                    )
-                                </fieldset>
-                            </div>
-
-                        }
-                    </div>
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-  </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/tradingDetails/views/vatChoice/start_date.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/start_date.scala.html
@@ -7,104 +7,97 @@
 
 @main_template(title = messages("pages.startDate.title")) {
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         startDateForm
-        )
+    )
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.startDate.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.startDate.heading")</h1>
 
-      <p>@messages("pages.startDate.para1")</p>
+    <p>@messages("pages.startDate.para1")</p>
 
-        @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.StartDateController.submit()) {
-            <div class="form-group">
+    @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.StartDateController.submit()) {
+        <div class="form-group">
 
-                @defining(DateTimeFormatter
-                        .ofLocalizedDate(java.time.format.FormatStyle.LONG)
-                        .withLocale(java.util.Locale.UK)) { formatter =>
+            @defining(DateTimeFormatter
+                    .ofLocalizedDate(java.time.format.FormatStyle.LONG)
+                    .withLocale(java.util.Locale.UK)) { formatter =>
 
-                        @vatInputRadioGroup(
-                            startDateForm("startDateRadio"),
-                            Seq(
-                                Some(StartDateView.COMPANY_REGISTRATION_DATE -> Messages("pages.startDate.radio.whenRegistered")),
-                                startDateForm.value.flatMap(_.ctActiveDate).map(d =>
-                                    StartDateView.BUSINESS_START_DATE -> messages("pages.startDate.radio.whenTrading", d.format(formatter))),
-                                Some(StartDateView.SPECIFIC_DATE -> Messages("pages.startDate.radio.specificDate"))
-                            ).flatten,
-                            '_labelAfter -> true,
-                            '_labelClass -> "block-label",
-                            '_legend -> ""
-                        )
+                    @vatInputRadioGroup(
+                        startDateForm("startDateRadio"),
+                        Seq(
+                            Some(StartDateView.COMPANY_REGISTRATION_DATE -> Messages("pages.startDate.radio.whenRegistered")),
+                            startDateForm.value.flatMap(_.ctActiveDate).map(d =>
+                                StartDateView.BUSINESS_START_DATE -> messages("pages.startDate.radio.whenTrading", d.format(formatter))),
+                            Some(StartDateView.SPECIFIC_DATE -> Messages("pages.startDate.radio.specificDate"))
+                        ).flatten,
+                        '_labelAfter -> true,
+                        '_labelClass -> "block-label",
+                        '_legend -> ""
+                    )
+                }
+
+                <div class="panel panel-indent hidden" id="specific_date_panel">
+                    <p>@messages("pages.startDate.panels.specificDate.para1")</p>
+                    <ul class="list list-bullet">
+                        <li>@messages("pages.startDate.panels.specificDate.bullet.2days")</li>
+                        <li>@messages("pages.startDate.panels.specificDate.bullet.3months")</li>
+                    </ul>
+
+                    <span class="form-hint">@messages("pages.startDate.panels.specificDate.hint")</span>
+
+
+                    @defining(startDateForm("startDate").errors.nonEmpty) { errorPresent =>
+                        <div class="form-date @if(errorPresent) { form-group-error }">
+
+                            <fieldset id="start-date">
+                                <legend></legend>
+                                <label><span class="hidden">Start date input</span>
+                                @startDateForm.error("startDate").map { error =>
+                                    <span class="error-notification" role="tooltip">
+                                        @messages(error.message, error.args: _*)
+                                    </span>
+                                }
+                                    @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
+                                    <input type="hidden" name="startDate" value="" id="startDate" class="hidden" />
+                                </label>
+
+                                @vatInput(
+                                    startDateForm("startDate.day"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.startDate.panels.specificDate.inputField.day"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    startDateForm("startDate.month"),
+                                    '_divClass -> "form-group",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 2,
+                                    '_label -> Messages("pages.startDate.panels.specificDate.inputField.month"),
+                                    '_labelClass -> "form-label"
+                                )
+
+                                @vatInput(
+                                    startDateForm("startDate.year"),
+                                    '_divClass -> "form-group form-group-year",
+                                    '_inputClass -> "form-control",
+                                    '_maxlength -> 4,
+                                    '_label -> Messages("pages.startDate.panels.specificDate.inputField.year"),
+                                    '_labelClass -> "form-label"
+                                )
+                            </fieldset>
+                        </div>
                     }
+                </div>
+        </div>
 
-                    <div class="panel panel-indent hidden" id="specific_date_panel">
-                        <p>@messages("pages.startDate.panels.specificDate.para1")</p>
-                        <ul class="list list-bullet">
-                            <li>@messages("pages.startDate.panels.specificDate.bullet.2days")</li>
-                            <li>@messages("pages.startDate.panels.specificDate.bullet.3months")</li>
-                        </ul>
-
-                        <span class="form-hint">@messages("pages.startDate.panels.specificDate.hint")</span>
-
-
-                        @defining(startDateForm("startDate").errors.nonEmpty) { errorPresent =>
-                            <div class="form-date @if(errorPresent) { form-group-error }">
-
-                                <fieldset id="start-date">
-                                    <legend></legend>
-                                    <label><span class="hidden">Start date input</span>
-                                    @startDateForm.error("startDate").map { error =>
-                                        <span class="error-notification" role="tooltip">
-                                            @messages(error.message, error.args: _*)
-                                        </span>
-                                    }
-                                        @*this is to make the clickable link in the error summary jump to the relevant place in the page*@
-                                        <input type="hidden" name="startDate" value="" id="startDate" class="hidden" />
-                                    </label>
-
-                                    @vatInput(
-                                        startDateForm("startDate.day"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.startDate.panels.specificDate.inputField.day"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        startDateForm("startDate.month"),
-                                        '_divClass -> "form-group",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 2,
-                                        '_label -> Messages("pages.startDate.panels.specificDate.inputField.month"),
-                                        '_labelClass -> "form-label"
-                                    )
-
-                                    @vatInput(
-                                        startDateForm("startDate.year"),
-                                        '_divClass -> "form-group form-group-year",
-                                        '_inputClass -> "form-control",
-                                        '_maxlength -> 4,
-                                        '_label -> Messages("pages.startDate.panels.specificDate.inputField.year"),
-                                        '_labelClass -> "form-label"
-                                    )
-                                </fieldset>
-                            </div>
-                        }
-                    </div>
-            </div>
-
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-  </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 
 <script type="text/javascript">

--- a/app/features/tradingDetails/views/vatChoice/taxable_turnover.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/taxable_turnover.scala.html
@@ -5,39 +5,34 @@
 
 @main_template(title = messages("pages.taxable.turnover.title")) {
 
-  <div class="column-one-third">
-
-      @errorSummary(
+    @errorSummary(
       Messages("app.common.errorSummaryLabel"),
       taxableTurnoverForm
-      )
+    )
 
-      <h1 class="form-title heading-large" id="pageHeading">@messages("pages.taxable.turnover.heading")</h1>
+    <h1 class="form-title heading-large" id="pageHeading">@messages("pages.taxable.turnover.heading")</h1>
 
-      <p>@messages("pages.taxable.turnover.p1")</p>
+    <p>@messages("pages.taxable.turnover.p1")</p>
 
-      @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.TaxableTurnoverController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="taxableTurnoverRadio"/>
-            @vatInputRadioGroup(
-                field = taxableTurnoverForm("taxableTurnoverRadio"),
-                Seq(
-                  TaxableTurnover.TAXABLE_YES -> Messages("app.common.yes"),
-                  TaxableTurnover.TAXABLE_NO -> Messages("app.common.no")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-       
-      </div>
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
+    @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.TaxableTurnoverController.submit()) {
+    <div class="form-group">
+      <fieldset class="inline">
+          <span id="taxableTurnoverRadio"/>
+          @vatInputRadioGroup(
+              field = taxableTurnoverForm("taxableTurnoverRadio"),
+              Seq(
+                TaxableTurnover.TAXABLE_YES -> Messages("app.common.yes"),
+                TaxableTurnover.TAXABLE_NO -> Messages("app.common.no")
+              ),
+              '_labelAfter -> true,
+              '_labelClass -> "block-label"
+          )
+      </fieldset>
+     
+    </div>
+    <div class="form-group">
+      <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
     </div>
 
+    }
 }

--- a/app/features/tradingDetails/views/vatChoice/voluntary_registration.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/voluntary_registration.scala.html
@@ -5,40 +5,35 @@
 
 @main_template(title = messages("pages.voluntary.registration.title")) {
 
-    <div class="column-one-third">
+    @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    voluntaryRegistrationForm
+    )
 
-        @errorSummary(
-        Messages("app.common.errorSummaryLabel"),
-        voluntaryRegistrationForm
-        )
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.heading")</h1>
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.heading")</h1>
+    <p>@messages("pages.voluntary.registration.para1")</p>
+    <p>@messages("pages.voluntary.registration.para2")</p>
 
-        <p>@messages("pages.voluntary.registration.para1")</p>
-        <p>@messages("pages.voluntary.registration.para2")</p>
+    @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.VoluntaryRegistrationController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="voluntaryRegistrationRadio"/>
+                @vatInputRadioGroup(
+                    field = voluntaryRegistrationForm("voluntaryRegistrationRadio"),
+                    Seq(
+                        VoluntaryRegistration.REGISTER_YES -> Messages("app.common.yes"),
+                        VoluntaryRegistration.REGISTER_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-        @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.VoluntaryRegistrationController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="voluntaryRegistrationRadio"/>
-                    @vatInputRadioGroup(
-                        field = voluntaryRegistrationForm("voluntaryRegistrationRadio"),
-                        Seq(
-                            VoluntaryRegistration.REGISTER_YES -> Messages("app.common.yes"),
-                            VoluntaryRegistration.REGISTER_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
-    </div>
-
+    }
 }

--- a/app/features/tradingDetails/views/vatChoice/voluntary_registration_reason.scala.html
+++ b/app/features/tradingDetails/views/vatChoice/voluntary_registration_reason.scala.html
@@ -5,45 +5,40 @@
 
 @main_template(title = messages("pages.voluntary.registration.reason.title")) {
 
-  <div class="column-two-thirds">
+  @errorSummary(
+    Messages("app.common.errorSummaryLabel"),
+    voluntaryRegistrationForm
+  )
 
-      @errorSummary(
-      Messages("app.common.errorSummaryLabel"),
-      voluntaryRegistrationForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.reason.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.voluntary.registration.reason.heading")</h1>
+  @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.VoluntaryRegistrationReasonController.submit()) {
+  <div class="form-group">
+    <fieldset class="inline">
+        <span id="voluntaryRegistrationReasonRadio"/>
+        @vatInputRadioGroup(
+            field = voluntaryRegistrationForm("voluntaryRegistrationReasonRadio"),
+            Seq(
+              VoluntaryRegistrationReason.SELLS -> Messages("pages.voluntary.registration.reason.radio.sells"),
+              VoluntaryRegistrationReason.INTENDS_TO_SELL -> Messages("pages.voluntary.registration.reason.radio.intendsToSell"),
+              VoluntaryRegistrationReason.NEITHER -> Messages("pages.voluntary.registration.reason.radio.neither")
+            ),
+            '_labelAfter -> true,
+            '_labelClass -> "block-label"
+        )
+    </fieldset>
 
-      @govHelpers.form(action = controllers.vatTradingDetails.vatChoice.routes.VoluntaryRegistrationReasonController.submit()) {
-      <div class="form-group">
-        <fieldset class="inline">
-            <span id="voluntaryRegistrationReasonRadio"/>
-            @vatInputRadioGroup(
-                field = voluntaryRegistrationForm("voluntaryRegistrationReasonRadio"),
-                Seq(
-                  VoluntaryRegistrationReason.SELLS -> Messages("pages.voluntary.registration.reason.radio.sells"),
-                  VoluntaryRegistrationReason.INTENDS_TO_SELL -> Messages("pages.voluntary.registration.reason.radio.intendsToSell"),
-                  VoluntaryRegistrationReason.NEITHER -> Messages("pages.voluntary.registration.reason.radio.neither")
-                ),
-                '_labelAfter -> true,
-                '_labelClass -> "block-label"
-            )
-        </fieldset>
-
-        <div class="panel panel-indent panel-border-narrow hidden" id="neither_panel">
-            <p>@messages("pages.voluntary.registration.reason.panels.neither.para")</p>
-        </div>
-
-      </div>
-
-      <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
+    <div class="panel panel-indent panel-border-narrow hidden" id="neither_panel">
+        <p>@messages("pages.voluntary.registration.reason.panels.neither.para")</p>
     </div>
 
+  </div>
+
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
+
+  }
 }
 
 <script type="text/javascript">

--- a/app/features/tradingDetails/views/vatEuTrading/eori_apply.scala.html
+++ b/app/features/tradingDetails/views/vatEuTrading/eori_apply.scala.html
@@ -5,42 +5,37 @@
 
 @main_template(title = messages("pages.applyEori.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         applyEoriForm,
         Seq("applyEori")
-        )
+    )
 
-        <h1 class="form-title heading-large" id="pageHeading">@messages("pages.applyEori.heading")</h1>
+    <h1 class="form-title heading-large" id="pageHeading">@messages("pages.applyEori.heading")</h1>
 
-        <p>@messages("pages.applyEori.para1")</p>
-        <h3 class="heading-medium">@messages("pages.applyEori.h3")</h3>
-        <p>@messages("pages.applyEori.para2")</p>
+    <p>@messages("pages.applyEori.para1")</p>
+    <h3 class="heading-medium">@messages("pages.applyEori.h3")</h3>
+    <p>@messages("pages.applyEori.para2")</p>
 
-        @govHelpers.form(action = controllers.vatTradingDetails.vatEuTrading.routes.ApplyEoriController.submit()) {
-            <div class="form-group">
-                <fieldset>
-                    <span id="applyEoriRadio"/>
-                    @vatInputRadioGroup(
-                        field = applyEoriForm("applyEoriRadio"),
-                        Seq(
-                            String.valueOf(ApplyEori.APPLY_EORI_YES) -> Messages("pages.applyEori.number.yes"),
-                            String.valueOf(ApplyEori.APPLY_EORI_NO) -> Messages("pages.applyEori.number.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+    @govHelpers.form(action = controllers.vatTradingDetails.vatEuTrading.routes.ApplyEoriController.submit()) {
+        <div class="form-group">
+            <fieldset>
+                <span id="applyEoriRadio"/>
+                @vatInputRadioGroup(
+                    field = applyEoriForm("applyEoriRadio"),
+                    Seq(
+                        String.valueOf(ApplyEori.APPLY_EORI_YES) -> Messages("pages.applyEori.number.yes"),
+                        String.valueOf(ApplyEori.APPLY_EORI_NO) -> Messages("pages.applyEori.number.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-        }
-
-    </div>
-
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+    }
 }
 

--- a/app/features/tradingDetails/views/vatEuTrading/eu_goods.scala.html
+++ b/app/features/tradingDetails/views/vatEuTrading/eu_goods.scala.html
@@ -5,38 +5,33 @@
 
 @main_template(title = messages("pages.euGoods.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         Messages("app.common.errorSummaryLabel"),
         euGoodsForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.euGoods.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.euGoods.heading")</h1>
 
-        @govHelpers.form(action = controllers.vatTradingDetails.vatEuTrading.routes.EuGoodsController.submit()) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="euGoodsRadio"/>
+    @govHelpers.form(action = controllers.vatTradingDetails.vatEuTrading.routes.EuGoodsController.submit()) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="euGoodsRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = euGoodsForm("euGoodsRadio"),
-                        Seq(
-                            EuGoods.EU_GOODS_YES -> Messages("app.common.yes"),
-                            EuGoods.EU_GOODS_NO -> Messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = euGoodsForm("euGoodsRadio"),
+                    Seq(
+                        EuGoods.EU_GOODS_YES -> Messages("app.common.yes"),
+                        EuGoods.EU_GOODS_NO -> Messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/application_submission_confirmation.scala.html
+++ b/app/views/pages/application_submission_confirmation.scala.html
@@ -8,44 +8,36 @@
 
 @main_template(title = Messages("pages.application.submission.confirmation.title"), scriptElem = Some(pageScripts), backEnabled = false) {
 
-    <div class="grid-row">
-        <div class="column-one-third">
-
-            <div class="transaction-banner--complete">
-                <h1 id="heading-application-submitted" class="transaction-banner__heading white--color">@messages("pages.application.submission.confirmation.heading")</h1>
-                <p class="white--color">@messages("pages.application.submission.confirmation.reference.number")</p>
-                <p class="white--color"><strong class="heading-medium">@refNo</strong></p>
-            </div>
+    <div class="transaction-banner--complete">
+        <h1 id="heading-application-submitted" class="transaction-banner__heading white--color">@messages("pages.application.submission.confirmation.heading")</h1>
+        <p class="white--color">@messages("pages.application.submission.confirmation.reference.number")</p>
+        <p class="white--color"><strong class="heading-medium">@refNo</strong></p>
+    </div>
 
 
-            <div class="form-group">
-                <h2 class="heading-medium">@messages("pages.application.submission.confirmation.whatNext.sub.heading")</h2>
-                <p>@messages("pages.application.submission.confirmation.whatNext.para1")</p>
-                <p>@messages("pages.application.submission.confirmation.whatNext.para2")</p>
-                <p>@messages("pages.application.submission.confirmation.whatNext.para3")</p>
+    <div class="form-group">
+        <h2 class="heading-medium">@messages("pages.application.submission.confirmation.whatNext.sub.heading")</h2>
+        <p>@messages("pages.application.submission.confirmation.whatNext.para1")</p>
+        <p>@messages("pages.application.submission.confirmation.whatNext.para2")</p>
+        <p>@messages("pages.application.submission.confirmation.whatNext.para3")</p>
 
-                <h2 class="heading-medium">@messages("pages.application.submission.confirmation.whileWait.sub.heading")</h2>
-                <p>@messages("pages.application.submission.confirmation.whileWait.para1")</p>
-                <p>@messages("pages.application.submission.confirmation.whileWait.para2")</p>
-                <div class="panel panel-indent" id="details-content-2" aria-hidden="false">
-                    <h3 class="heading-small">@messages("pages.application.submission.confirmation.whileWait.example")</h3>
-                    <p>@Html(messages("pages.application.submission.confirmation.whileWait.example.para1"))</p>
-                </div>
-                <p>@messages("pages.application.submission.confirmation.whileWait.para3")</p>
-
-            </div>
-
-            @form(action = controllers.routes.WelcomeController.show()) {
-                <div class="form-group">
-                    <button class="button-get-started" role="button" id="save-and-continue">@messages("pages.application.submission.confirmation.button")</button>
-                </div>
-
-            }
-
-
+        <h2 class="heading-medium">@messages("pages.application.submission.confirmation.whileWait.sub.heading")</h2>
+        <p>@messages("pages.application.submission.confirmation.whileWait.para1")</p>
+        <p>@messages("pages.application.submission.confirmation.whileWait.para2")</p>
+        <div class="panel panel-indent" id="details-content-2" aria-hidden="false">
+            <h3 class="heading-small">@messages("pages.application.submission.confirmation.whileWait.example")</h3>
+            <p>@Html(messages("pages.application.submission.confirmation.whileWait.example.para1"))</p>
         </div>
+        <p>@messages("pages.application.submission.confirmation.whileWait.para3")</p>
 
     </div>
+
+    @form(action = controllers.routes.WelcomeController.show()) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="save-and-continue">@messages("pages.application.submission.confirmation.button")</button>
+        </div>
+
+    }
 
 
     @***

--- a/app/views/pages/test/sic_stub.scala.html
+++ b/app/views/pages/test/sic_stub.scala.html
@@ -4,42 +4,34 @@
 
 @main_template(title = "SIC codes") {
 
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">Enter 1-4, 8 digit SIC codes:</h1>
+    </header>
 
-    <div class="grid-row">
-        <div class="column-one-third">
+    <p><button class="btn button" type="button" onclick="fillCulturalCodes()">Cultural compliance</button></p>
+    <p><button class="btn button" type="button" onclick="fillLabourCodes()">Labour compliance</button></p>
+    <p><button class="btn button" type="button" onclick="fillFinancialCodes()">Financial compliance</button></p>
+    <p><button class="btn button" type="button" onclick="fillSingleCode()">Single code - no compliance</button></p>
+    <p><button class="btn button" type="button" onclick="fillMultipleCodes()">Multiple codes - no compliance</button></p>
+    <p><button class="btn button" type="button" onclick="clearCodes()">Clear</button></p>
 
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="pageHeading">Enter 1-4, 8 digit SIC codes:</h1>
-            </header>
+    @form(action = controllers.test.routes.SicStubController.submit()) {
+        <div class="form-group">
+            <fieldset>
 
-            <p><button class="btn button" type="button" onclick="fillCulturalCodes()">Cultural compliance</button></p>
-            <p><button class="btn button" type="button" onclick="fillLabourCodes()">Labour compliance</button></p>
-            <p><button class="btn button" type="button" onclick="fillFinancialCodes()">Financial compliance</button></p>
-            <p><button class="btn button" type="button" onclick="fillSingleCode()">Single code - no compliance</button></p>
-            <p><button class="btn button" type="button" onclick="fillMultipleCodes()">Multiple codes - no compliance</button></p>
-            <p><button class="btn button" type="button" onclick="clearCodes()">Clear</button></p>
+                <p><input type="text" name="sicCode1" maxlength="8" title="sic1" value=""/></p>
+                <p><input type="text" name="sicCode2" maxlength="8" title="sic2" value=""/></p>
+                <p><input type="text" name="sicCode3" maxlength="8" title="sic4" value=""/></p>
+                <p><input type="text" name="sicCode4" maxlength="8" title="sic4" value=""/></p>
 
-            @form(action = controllers.test.routes.SicStubController.submit()) {
-                <div class="form-group">
-                    <fieldset>
-
-                        <p><input type="text" name="sicCode1" maxlength="8" title="sic1" value=""/></p>
-                        <p><input type="text" name="sicCode2" maxlength="8" title="sic2" value=""/></p>
-                        <p><input type="text" name="sicCode3" maxlength="8" title="sic4" value=""/></p>
-                        <p><input type="text" name="sicCode4" maxlength="8" title="sic4" value=""/></p>
-
-                    </fieldset>
-
-                </div>
-
-                <div class="form-group">
-                    <button class="btn button" type="submit" id="submit">Submit</button>
-                </div>
-            }
+            </fieldset>
 
         </div>
 
-    </div>
+        <div class="form-group">
+            <button class="btn button" type="submit" id="submit">Submit</button>
+        </div>
+    }
 }
 
 

--- a/app/views/pages/vatContact/business_contact_details.scala.html
+++ b/app/views/pages/vatContact/business_contact_details.scala.html
@@ -5,83 +5,77 @@
 
 @main_template(title = messages("pages.businessContactDetails.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+  messages("app.common.errorSummaryLabel"),
+  businessContactDetailsForm
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      businessContactDetailsForm
-      )
+  <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.businessContactDetails.heading")</h1>
 
-      <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.businessContactDetails.heading")</h1>
+  <p>@Html(messages("pages.businessContactDetails.para1"))</p>
 
-      <p>@Html(messages("pages.businessContactDetails.para1"))</p>
+  @govHelpers.form(action = controllers.vatContact.routes.BusinessContactDetailsController.submit()) {
+      <div class="form-group">
+          <fieldset>
 
-      @govHelpers.form(action = controllers.vatContact.routes.BusinessContactDetailsController.submit()) {
-          <div class="form-group">
-              <fieldset>
+              <legend>@Html(messages("pages.businessContactDetails.para2"))</legend>
 
-                  <legend>@Html(messages("pages.businessContactDetails.para2"))</legend>
+              @businessContactDetailsForm.errors.find(_.args.contains("businessContactDetails")).map { error =>
+                  @govHelpers.errorInline("businessContactDetails", messages(error.message))
+              }
 
-                  @businessContactDetailsForm.errors.find(_.args.contains("businessContactDetails")).map { error =>
-                      @govHelpers.errorInline("businessContactDetails", messages(error.message))
-                  }
+              @vatInput(
+                  businessContactDetailsForm("email"),
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 70,
+                  '_label -> messages("pages.businessContactDetails.emailAddress.label")
+              )
 
-                  @vatInput(
-                      businessContactDetailsForm("email"),
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 70,
-                      '_label -> messages("pages.businessContactDetails.emailAddress.label")
-                  )
+              <div class="panel indent" id="details-content-0" aria-hidden="true">
+                  <p>@Html(messages("pages.businessContactDetails.para3"))</p>
+              </div>
+              <br />
 
-                  <div class="panel indent" id="details-content-0" aria-hidden="true">
-                      <p>@Html(messages("pages.businessContactDetails.para3"))</p>
-                  </div>
-                  <br />
+              @vatInput(
+                  businessContactDetailsForm("daytimePhone"),
+                  '_type -> "text",
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 20,
+                  '_label -> messages("pages.businessContactDetails.daytimePhone.label")
+              )
 
-                  @vatInput(
-                      businessContactDetailsForm("daytimePhone"),
-                      '_type -> "text",
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 20,
-                      '_label -> messages("pages.businessContactDetails.daytimePhone.label")
-                  )
-
-                  @vatInput(
-                      businessContactDetailsForm("mobile"),
-                      '_type -> "text",
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 20,
-                      '_label -> messages("pages.businessContactDetails.mobile.label")
-                  )
+              @vatInput(
+                  businessContactDetailsForm("mobile"),
+                  '_type -> "text",
+                  '_divClass -> "form-group",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 20,
+                  '_label -> messages("pages.businessContactDetails.mobile.label")
+              )
 
 
-                  @vatInput(
-                      businessContactDetailsForm("website"),
-                      '_type -> "text",
-                      '_divClass -> "form-group",
-                      '_inputClass -> "form-control",
-                      '_labelClass -> "cascading",
-                      '_maxlength -> 255,
-                      '_label -> messages("pages.businessContactDetails.website.label")
-                  )
+              @vatInput(
+                  businessContactDetailsForm("website"),
+                  '_type -> "text",
+                  '_inputClass -> "form-control",
+                  '_labelClass -> "cascading",
+                  '_maxlength -> 255,
+                  '_label -> messages("pages.businessContactDetails.website.label")
+              )
 
-              </fieldset>
+          </fieldset>
 
-          </div>
+      </div>
 
-          <div class="form-group">
-              <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-          </div>
-      }
-
-    </div>
-
+      <div class="form-group">
+          <button class="btn button" type="submit" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+      </div>
+  }
 }
 
 <script type="text/javascript">

--- a/app/views/pages/vatContact/ppob/ppob.scala.html
+++ b/app/views/pages/vatContact/ppob/ppob.scala.html
@@ -6,40 +6,35 @@
 
 @main_template(title = messages("pages.ppob.title")) {
 
-  <div class="column-one-third">
+  @errorSummary(
+  messages("app.common.errorSummaryLabel"),
+  ppobform
+  )
 
-      @errorSummary(
-      messages("app.common.errorSummaryLabel"),
-      ppobform
+  <header class="page-header">
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.ppob.heading")</h1>
+  </header>
+
+  <p>@Html(messages("pages.ppob.p1"))</p>
+  <p>@Html(messages("pages.ppob.p2"))</p>
+
+  @govHelpers.form(action = controllers.vatContact.ppob.routes.PpobController.submit()) {
+  <div class="form-group" id="ppobRadio">
+
+      @vatInputRadioGroup(
+          field = ppobform("ppobRadio"),
+          addresses.map( a => (a.id, a.asLabel)) :+
+                  ("other" -> messages("pages.ppob.different.address")),
+          '_legend -> messages("pages.ppob.heading"),
+          '_legendClass -> "hidden",
+          '_labelAfter -> true,
+          '_labelClass -> "block-label"
       )
 
-      <header class="page-header">
-          <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.ppob.heading")</h1>
-      </header>
+  </div>
+  <div class="form-group">
+    <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+  </div>
 
-      <p>@Html(messages("pages.ppob.p1"))</p>
-      <p>@Html(messages("pages.ppob.p2"))</p>
-
-      @govHelpers.form(action = controllers.vatContact.ppob.routes.PpobController.submit()) {
-      <div class="form-group" id="ppobRadio">
-
-          @vatInputRadioGroup(
-              field = ppobform("ppobRadio"),
-              addresses.map( a => (a.id, a.asLabel)) :+
-                      ("other" -> messages("pages.ppob.different.address")),
-              '_legend -> messages("pages.ppob.heading"),
-              '_legendClass -> "hidden",
-              '_labelAfter -> true,
-              '_labelClass -> "block-label"
-          )
-
-      </div>
-          <div class="form-group">
-        <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-      </div>
-
-      }
-
-    </div>
-
+  }
 }

--- a/app/views/pages/vatEligibility/applying_for_any_of.scala.html
+++ b/app/views/pages/vatEligibility/applying_for_any_of.scala.html
@@ -5,41 +5,36 @@
 
 @main_template(title = messages("pages.eligibility.applyingForAnyOf.title")) {
 
-    <div class="column-two-thirds">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         applyingForAnyOfForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.applyingForAnyOf.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.applyingForAnyOf.heading")</h1>
 
-        <p>@messages("pages.eligibility.applyingForAnyOf.p1")</p>
-        <p>@messages("pages.eligibility.applyingForAnyOf.p2")</p>
+    <p>@messages("pages.eligibility.applyingForAnyOf.p1")</p>
+    <p>@messages("pages.eligibility.applyingForAnyOf.p2")</p>
 
-        @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("applyingForAnyOf")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="applyingForAnyOfRadio"/>
+    @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("applyingForAnyOf")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="applyingForAnyOfRadio"/>
 
-                    @vatInputRadioGroup(
-                        field = applyingForAnyOfForm("applyingForAnyOfRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+                @vatInputRadioGroup(
+                    field = applyingForAnyOfForm("applyingForAnyOfRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/vatEligibility/company_will_do_any_of.scala.html
+++ b/app/views/pages/vatEligibility/company_will_do_any_of.scala.html
@@ -5,50 +5,45 @@
 
 @main_template(title = messages("pages.eligibility.companyWillDoAnyOf.title")) {
 
-    <div class="column-two-thirds">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         companyWillDoAnyOfForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.companyWillDoAnyOf.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.companyWillDoAnyOf.heading")</h1>
 
-        <p>@messages("pages.eligibility.companyWillDoAnyOf.p1")</p>
+    <p>@messages("pages.eligibility.companyWillDoAnyOf.p1")</p>
 
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet1"))</li>
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet2"))</li>
-                <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet3"))</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("companyWillDoAnyOf")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="companyWillDoAnyOfRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = companyWillDoAnyOfForm("companyWillDoAnyOfRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet1"))</li>
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet2"))</li>
+            <li>@Html(messages("pages.eligibility.companyWillDoAnyOf.bullet3"))</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("companyWillDoAnyOf")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="companyWillDoAnyOfRadio"/>
+
+                @vatInputRadioGroup(
+                    field = companyWillDoAnyOfForm("companyWillDoAnyOfRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/vatEligibility/do_any_apply_to_you.scala.html
+++ b/app/views/pages/vatEligibility/do_any_apply_to_you.scala.html
@@ -5,48 +5,43 @@
 
 @main_template(title = messages("pages.eligibility.doAnyApplyToYou.title")) {
 
-    <div class="column-two-thirds">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         doAnyApplyToYouForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doAnyApplyToYou.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doAnyApplyToYou.heading")</h1>
 
-        <p>@messages("pages.eligibility.doAnyApplyToYou.p1")</p>
+    <p>@messages("pages.eligibility.doAnyApplyToYou.p1")</p>
 
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet1"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet2"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet3"))</li>
-                <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet4"))</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("doAnyApplyToYou")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="doAnyApplyToYouRadio"/>
-                    @vatInputRadioGroup(
-                        field = doAnyApplyToYouForm("doAnyApplyToYouRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet1"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet2"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet3"))</li>
+            <li>@Html(messages("pages.eligibility.doAnyApplyToYou.bullet4"))</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("doAnyApplyToYou")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="doAnyApplyToYouRadio"/>
+                @vatInputRadioGroup(
+                    field = doAnyApplyToYouForm("doAnyApplyToYouRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/vatEligibility/doing_business_abroad.scala.html
+++ b/app/views/pages/vatEligibility/doing_business_abroad.scala.html
@@ -5,51 +5,46 @@
 
 @main_template(title = messages("pages.eligibility.doingBusinessAbroad.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         doingBusinessAbroadForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doingBusinessAbroad.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.doingBusinessAbroad.heading")</h1>
 
-        <p>@messages("pages.eligibility.doingBusinessAbroad.p1")</p>
+    <p>@messages("pages.eligibility.doingBusinessAbroad.p1")</p>
 
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@Html(messages("pages.eligibility.doingBusinessAbroad.bullet1"))</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet2")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet3")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet4")</li>
-                <li>@messages("pages.eligibility.doingBusinessAbroad.bullet5")</li>
-            </ul>
-        </div>
-
-        @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("doingBusinessAbroad")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="doingBusinessAbroadRadio"/>
-
-                    @vatInputRadioGroup(
-                        field = doingBusinessAbroadForm("doingBusinessAbroadRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
-
-
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
-
-        }
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@Html(messages("pages.eligibility.doingBusinessAbroad.bullet1"))</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet2")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet3")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet4")</li>
+            <li>@messages("pages.eligibility.doingBusinessAbroad.bullet5")</li>
+        </ul>
     </div>
 
+    @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("doingBusinessAbroad")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="doingBusinessAbroadRadio"/>
+
+                @vatInputRadioGroup(
+                    field = doingBusinessAbroadForm("doingBusinessAbroadRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
+
+
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
+
+    }
 }

--- a/app/views/pages/vatEligibility/eligible.scala.html
+++ b/app/views/pages/vatEligibility/eligible.scala.html
@@ -3,61 +3,55 @@
 
 @main_template(title = messages("pages.serviceCriteriaSuccess.title")) {
 
-<div class="grid-row">
-    <div class="column-one-third">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaSuccess.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaSuccess.heading")</h1>
-        </header>
+    <p>@messages("pages.serviceCriteriaSuccess.para1")</p>
 
-        <p>@messages("pages.serviceCriteriaSuccess.para1")</p>
-
-        <div class="form-group">
-            <ul class="list list-bullet">
-                <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet1")</li>
-                <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet2")</li>
-            </ul>
-        </div>
-
-        <p>@messages("pages.serviceCriteriaSuccess.note.registrationTime")</p>
-
-        <div class="form-group">
-
-            <details role="group">
-                <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.title")</span></summary>
-                <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para1")</p>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para2")</p>
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.charge"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.reclaim"))</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.invoices")</li>
-                    </ul>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para3")</p>
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para4")</p>
-                </div>
-            </details>
-
-            <details role="group">
-                <summary role="button" aria-controls="details-content-2" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.title")</span></summary>
-                <div class="panel panel-indent" id="details-content-2" aria-hidden="true">
-                    <p>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.para1")</p>
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.charge"))</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.pay")</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.submit")</li>
-                        <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.records")</li>
-                    </ul>
-                </div>
-            </details>
-        </div>
-
-        @form(action = controllers.vatTradingDetails.vatChoice.routes.EligibilitySuccessController.submit()) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet1")</li>
+            <li>@messages("pages.serviceCriteriaSuccess.bullet.details.bullet2")</li>
+        </ul>
     </div>
 
-</div>
+    <p>@messages("pages.serviceCriteriaSuccess.note.registrationTime")</p>
+
+    <div class="form-group">
+
+        <details role="group">
+            <summary role="button" aria-controls="details-content-1" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.title")</span></summary>
+            <div class="panel panel-indent" id="details-content-1" aria-hidden="true">
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para1")</p>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para2")</p>
+                <ul class="list list-bullet">
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.charge"))</li>
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.reclaim"))</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.bullet.invoices")</li>
+                </ul>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para3")</p>
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatVoluntarily.para4")</p>
+            </div>
+        </details>
+
+        <details role="group">
+            <summary role="button" aria-controls="details-content-2" aria-expanded="false"><span class="summary">@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.title")</span></summary>
+            <div class="panel panel-indent" id="details-content-2" aria-hidden="true">
+                <p>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.para1")</p>
+                <ul class="list list-bullet">
+                    <li>@Html(messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.charge"))</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.pay")</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.submit")</li>
+                    <li>@messages("pages.serviceCriteriaSuccess.panels.vatResponsibilities.bullet.records")</li>
+                </ul>
+            </div>
+        </details>
+    </div>
+
+    @form(action = controllers.vatTradingDetails.vatChoice.routes.EligibilitySuccessController.submit()) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/views/pages/vatEligibility/have_nino.scala.html
+++ b/app/views/pages/vatEligibility/have_nino.scala.html
@@ -5,37 +5,32 @@
 
 @main_template(title = messages("pages.eligibility.haveNino.title")) {
 
-    <div class="column-one-third">
-
-        @errorSummary(
+    @errorSummary(
         messages("app.common.errorSummaryLabel"),
         haveNinoForm
-        )
+    )
 
-        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.haveNino.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.haveNino.heading")</h1>
 
-        @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("haveNino")) {
-            <div class="form-group">
-                <fieldset class="inline">
-                    <span id="haveNinoRadio"/>
-                    @vatInputRadioGroup(
-                        field = haveNinoForm("haveNinoRadio"),
-                        Seq(
-                            "true" -> messages("app.common.yes"),
-                            "false" -> messages("app.common.no")
-                        ),
-                        '_labelAfter -> true,
-                        '_labelClass -> "block-label"
-                    )
-                </fieldset>
-            </div>
+    @govHelpers.form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.submit("haveNino")) {
+        <div class="form-group">
+            <fieldset class="inline">
+                <span id="haveNinoRadio"/>
+                @vatInputRadioGroup(
+                    field = haveNinoForm("haveNinoRadio"),
+                    Seq(
+                        "true" -> messages("app.common.yes"),
+                        "false" -> messages("app.common.no")
+                    ),
+                    '_labelAfter -> true,
+                    '_labelClass -> "block-label"
+                )
+            </fieldset>
+        </div>
 
-            <div class="form-group">
-                <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
-            </div>
+        <div class="form-group">
+            <button class="button-save-and-continue" role="button" id="save-and-continue">@messages("app.common.saveAndContinue")</button>
+        </div>
 
-        }
-
-    </div>
-
+    }
 }

--- a/app/views/pages/vatEligibility/ineligible.scala.html
+++ b/app/views/pages/vatEligibility/ineligible.scala.html
@@ -3,94 +3,87 @@
 
 @main_template(title = messages("pages.serviceCriteriaFailure.title")) {
 
-    <div class="grid-row">
-        <div class="column-two-thirds">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
+    </header>
 
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.serviceCriteriaFailure.heading")</h1>
-            </header>
+    @defining((in:String) => if (in == thisSection) "" else "hidden") { cssClass =>
 
-            @defining((in:String) => if (in == thisSection) "" else "hidden") { cssClass =>
+        <div id="nino-text" class="@cssClass("haveNino")">
 
-                <div id="nino-text" class="@cssClass("haveNino")">
+            <p>@messages("pages.serviceCriteriaFailure.nino.p1")</p>
 
-                    <p>@messages("pages.serviceCriteriaFailure.nino.p1")</p>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
-
-                </div>
-
-                <div id="business-abroad-text" class="@cssClass("doingBusinessAbroad")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet2"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p1"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p2"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p3"))</p>
-
-                </div>
-
-                <div id="do-any-apply-to-you-text" class="@cssClass("doAnyApplyToYou")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet2"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet3"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet4"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.p1"))</p>
-
-                </div>
-
-                <div id="applying-for-any-of-text" class="@cssClass("applyingForAnyOf")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet2"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p1"))</p>
-                    <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p2"))</p>
-
-                </div>
-
-                <div id="company-will-do-any-of-text" class="@cssClass("companyWillDoAnyOf")">
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.p1"))</p>
-
-                    <ul class="list list-bullet">
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet1"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet2"))</li>
-                        <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet3"))</li>
-                    </ul>
-
-                    <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
-
-                </div>
-
-
-                <p>&nbsp;</p>
-            }
-
-            @form(action = Call("GET", "https://online.hmrc.gov.uk/registration/newbusiness/business-allowed")) {
-                <div class="form-group">
-                    <button type="submit" class="btn button" role="button" id="continue">
-                    @messages("pages.serviceCriteriaFailure.button.linkToLegacyApp")
-                    </button>
-                </div>
-            }
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
 
         </div>
 
-    </div>
+        <div id="business-abroad-text" class="@cssClass("doingBusinessAbroad")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.bullet2"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p1"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p2"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.businessAbroad.p3"))</p>
+
+        </div>
+
+        <div id="do-any-apply-to-you-text" class="@cssClass("doAnyApplyToYou")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet2"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet3"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.bullet4"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.doAnyApplyToYou.p1"))</p>
+
+        </div>
+
+        <div id="applying-for-any-of-text" class="@cssClass("applyingForAnyOf")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp2"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.bullet2"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p1"))</p>
+            <p>@Html(messages("pages.serviceCriteriaFailure.applyingForAnyOf.p2"))</p>
+
+        </div>
+
+        <div id="company-will-do-any-of-text" class="@cssClass("companyWillDoAnyOf")">
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.p1"))</p>
+
+            <ul class="list list-bullet">
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet1"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet2"))</li>
+                <li>@Html(messages("pages.serviceCriteriaFailure.companyWillDoAnyOf.bullet3"))</li>
+            </ul>
+
+            <p>@Html(messages("pages.serviceCriteriaFailure.linkToLegacyApp"))</p>
+
+        </div>
+
+
+        <p>&nbsp;</p>
+    }
+
+    @form(action = Call("GET", "https://online.hmrc.gov.uk/registration/newbusiness/business-allowed")) {
+        <div class="form-group">
+            <button type="submit" class="btn button" role="button" id="continue">
+            @messages("pages.serviceCriteriaFailure.button.linkToLegacyApp")
+            </button>
+        </div>
+    }
 }

--- a/app/views/pages/vatEligibility/use_this_service.scala.html
+++ b/app/views/pages/vatEligibility/use_this_service.scala.html
@@ -3,21 +3,15 @@
 
 @main_template(title = messages("pages.eligibility.start.title")) {
 
-<div class="grid-row">
-    <div class="column-one-third">
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.start.heading")</h1>
+    </header>
 
-        <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.eligibility.start.heading")</h1>
-        </header>
-
-        <p>@messages("pages.eligibility.start.para1")</p>
-        <br>
-        @form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.show("haveNino")) {
-            <div class="form-group">
-                <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-            </div>
-        }
-    </div>
-
-</div>
+    <p>@messages("pages.eligibility.start.para1")</p>
+    <br>
+    @form(action = controllers.vatEligibility.routes.ServiceCriteriaQuestionsController.show("haveNino")) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+        </div>
+    }
 }

--- a/app/views/pages/welcome.scala.html
+++ b/app/views/pages/welcome.scala.html
@@ -3,46 +3,41 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 
 @main_template(title = messages("pages.welcome.title")) {
-    <div class="grid-row">
-        <div class="column-one-third">
 
-            <header class="page-header">
-                <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.welcome.heading")</h1>
-            </header>
+    <header class="page-header">
+        <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.welcome.heading")</h1>
+    </header>
 
-            <p>@messages("pages.welcome.p1")</p>
+    <p>@messages("pages.welcome.p1")</p>
 
-            <div class="form-group">
-                <ul class="list list-bullet">
-                    <li>@messages("pages.welcome.bullet1")</li>
-                    <li>@messages("pages.welcome.bullet2")</li>
-                </ul>
-            </div>
-
-            <p>@messages("pages.welcome.p2")</p>
-            <p>@messages("pages.welcome.p3")</p>
-
-            <div class="form-group">
-            @form(action = controllers.routes.TwirlViewController.renderViewAuthorised()) {
-                <div class="form-group">
-                    <button class="button-get-started" role="button" id="start">@messages("pages.welcome.button.start")
-                    </button>
-                </div>
-            }
-            </div>
-
-            <p>@messages("pages.welcome.p4")</p>
-            <div class="form-group">
-                <ul class="list list-bullet">
-                    <li>@messages("pages.welcome.bullet3")</li>
-                    <li>@messages("pages.welcome.bullet4")</li>
-                    <li>@messages("pages.welcome.bullet5")</li>
-                    <li>@messages("pages.welcome.bullet6")</li>
-                </ul>
-            </div>
-            <p>@messages("pages.welcome.p5")</p>
-
-        </div>
-
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@messages("pages.welcome.bullet1")</li>
+            <li>@messages("pages.welcome.bullet2")</li>
+        </ul>
     </div>
+
+    <p>@messages("pages.welcome.p2")</p>
+    <p>@messages("pages.welcome.p3")</p>
+
+    <div class="form-group">
+    @form(action = controllers.routes.TwirlViewController.renderViewAuthorised()) {
+        <div class="form-group">
+            <button class="button-get-started" role="button" id="start">@messages("pages.welcome.button.start")
+            </button>
+        </div>
+    }
+    </div>
+
+    <p>@messages("pages.welcome.p4")</p>
+    <div class="form-group">
+        <ul class="list list-bullet">
+            <li>@messages("pages.welcome.bullet3")</li>
+            <li>@messages("pages.welcome.bullet4")</li>
+            <li>@messages("pages.welcome.bullet5")</li>
+            <li>@messages("pages.welcome.bullet6")</li>
+        </ul>
+    </div>
+    <p>@messages("pages.welcome.p5")</p>
+
 }


### PR DESCRIPTION
around the cointent that sits within .content__body wrapper we get
from the HMRC template:

.grid-row > .column-one-third
.grid-row > .column-two-thirds
.column-two-thirds
.column-one-third

The majority of the time none of these classes are doing anything. So at best we have 1 or 2 extra content div wrapper that are redundant. But every now and then they are actually picking up the styles for the classes assigned to the divs. Meaning that the content displays as either 1/3 or 2/3 of the the parent .content__body which is already set to 61.6666667% width, which breaks the layout.

### Before (if classes were picking up styles)
![screen shot 2017-10-12 at 13 59 24](https://user-images.githubusercontent.com/1692222/31497064-a38da770-af55-11e7-8453-dcd9a7710bbb.png)

### After
![screen shot 2017-10-12 at 13 59 38](https://user-images.githubusercontent.com/1692222/31497071-ac1a40b0-af55-11e7-9aba-2bb74d17831b.png)
