### PR TITLE
Updating confirmation page to pass accessibility and bumping AF version

### DIFF
--- a/app/views/pages/application_submission_confirmation.scala.html
+++ b/app/views/pages/application_submission_confirmation.scala.html
@@ -8,10 +8,13 @@
 
 @main_template(title = Messages("pages.application.submission.confirmation.title"), scriptElem = Some(pageScripts), backEnabled = false) {
 
-    <div class="transaction-banner--complete">
-        <h1 id="heading-application-submitted" class="transaction-banner__heading white--color">@messages("pages.application.submission.confirmation.heading")</h1>
-        <p class="white--color">@messages("pages.application.submission.confirmation.reference.number")</p>
-        <p class="white--color"><strong class="heading-medium">@refNo</strong></p>
+    <div class="govuk-box-highlight">
+        <h1 id="heading-application-submitted" class="heading-xlarge">@messages("pages.application.submission.confirmation.heading")</h1>
+        <p class="font-large">
+            @messages("pages.application.submission.confirmation.reference.number")
+            <br>
+            <strong class="heading-medium">@refNo</strong>
+        </p>
     </div>
 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -47,7 +47,7 @@ play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 //play.crypto.secret="yIFxaTxyLz5Fwh7oVZbNKwPfNUbkZc0FmCU8ulrziNTngOrLzsWVwwnOZ4jxYMmp"
 
 assets {
-  version = "2.248.1"
+  version = "2.252.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
The confirmation page fails accessibility. This PR updates the markup to conform with GOV.UK standards and bumps to the latest version of HMRC AF to fix this issue.

Note: the AF version bump also introduces many other updates, such as latest phase banner colours (seen in screenshot), among other updates.

### Before
![screen shot 2017-10-18 at 16 14 04](https://user-images.githubusercontent.com/1692222/31726733-a480ba86-b41f-11e7-8356-2d32bf4e6036.png)

### After
![screen shot 2017-10-18 at 16 07 08](https://user-images.githubusercontent.com/1692222/31726757-b0906ff6-b41f-11e7-8d1d-fe11330feb5b.png)

