### PR TITLE
Update check your answers page inline with GDS recommendations

### DIFF
--- a/app/views/helpers/templates/summaryRow.scala.html
+++ b/app/views/helpers/templates/summaryRow.scala.html
@@ -6,16 +6,16 @@
    @messages(ans)<br>
 }
 
-<tr id="@{row.id}">
-    <td id="@{row.id}Question">@messages(s"pages.summary.${row.id}", questionArg)</td>
-    <td id="@{row.id}Answer">
-        @for(answer <- row.answerMessageKeys) {
-            @displayAnswer(answer)
-        }
-    </td>
-    <td class="change-answer">
-        @row.changeLink.map { linkLocation =>
-            <a href="@linkLocation" id="@{row.id}ChangeLink">@messages("app.common.change")</a>
-        }
-    </td>
-</tr>
+<div id="@{row.id}">
+  <dt class="cya-question" id="@{row.id}Question">@messages(s"pages.summary.${row.id}", questionArg)</dt>
+  <dd class="cya-answer" id="@{row.id}Answer">
+    @for(answer <- row.answerMessageKeys) {
+        @displayAnswer(answer)
+    }
+  </dd>
+  <dd class="cya-change">
+    @row.changeLink.map { linkLocation =>
+        <a href="@linkLocation" id="@{row.id}ChangeLink">@messages("app.common.change") <span class="visuallyhidden">&nbsp; @messages(s"pages.summary.${row.id}", questionArg)</span></a>
+    }
+  </dd>
+</div>

--- a/app/views/pages/summary.scala.html
+++ b/app/views/pages/summary.scala.html
@@ -5,26 +5,26 @@
 
 @main_template(title = messages("pages.summary.title")) {
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.summary.heading")</h1>
+  <h1 class="form-title heading-large" id="pageHeading">@messages("pages.summary.heading")</h1>
 
-    @for(section <- summaryModel.sections) {
-        @if(section.display) {
-            <section>
-                <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
-                <table class="check-your-answers form-group">
-                    @for((row, doDisplayRow) <- section.rows) {
-                        @if(doDisplayRow) {
-                            @summaryRow(row, questionArg)
-                        }
-                    }
-                </table>
-            </section>
-        }
+  @for(section <- summaryModel.sections) {
+    @if(section.display) {
+      <section>
+        <h2 class="heading-medium">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>
+        <dl class="govuk-check-your-answers cya-questions-long">
+          @for((row, doDisplayRow) <- section.rows) {
+            @if(doDisplayRow) {
+                @summaryRow(row, questionArg)
+            }
+          }
+        </dl>
+      </section>
     }
+  }
 
-    @form(action = controllers.routes.ApplicationSubmissionController.show()) {
-        <div class="form-group">
-            <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
-        </div>
-    }
+  @form(action = controllers.routes.ApplicationSubmissionController.show()) {
+    <div class="form-group">
+      <button class="button-get-started" role="button" id="save-and-continue">@messages("app.common.continue")</button>
+    </div>
+  }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -48,7 +48,7 @@ play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 //play.crypto.secret="yIFxaTxyLz5Fwh7oVZbNKwPfNUbkZc0FmCU8ulrziNTngOrLzsWVwwnOZ4jxYMmp"
 
 assets {
-  version = "2.252.0"
+  version = "2.253.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
This PR updates the check your answers page to use dl's moving away
from tables.

Changes made:
- update to dl from table
- reduce heading size using .heading-large

Note: Visually this page hasn't changed that much.

### Before
![vat-fe-before](https://user-images.githubusercontent.com/1692222/33312807-d2aee2ae-d420-11e7-86a8-fdae8729afc4.jpg)

### After
![vat-fe-after](https://user-images.githubusercontent.com/1692222/33312831-ddb226a2-d420-11e7-8aaf-97f6eee25c11.jpg)
