### PR TITLE
Uplift HMRC AF to v3 and uplift styles

### DIFF
--- a/app/views/helpers/mainContentHeader.scala.html
+++ b/app/views/helpers/mainContentHeader.scala.html
@@ -2,9 +2,7 @@
 
 @backButton = {
     @if(backButtonEnabled) {
-        <div style="width:40%; display: inline-block" align="left" class="form-group-compound">
-            <a id="back" class="back-link" href="javascript:history.back()">@messages("app.common.back")</a>
-        </div>
+        <a id="back" class="link-back" href="javascript:history.back()">@messages("app.common.back")</a>
     }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,7 +57,7 @@ play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 //play.crypto.secret="yIFxaTxyLz5Fwh7oVZbNKwPfNUbkZc0FmCU8ulrziNTngOrLzsWVwwnOZ4jxYMmp"
 
 assets {
-  version = "2.253.0"
+  version = "3.0.2"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,4 +1,5 @@
 @import 'form-validation.css';
+@import 'taas.css';
 /* position labels above input fields in cascading forms */
 label.cascading span {
 	display: block;
@@ -55,6 +56,7 @@ td {
 }
 
 
-.fill-width {
-	width: 95%
+.char-counter .fill-width {
+	width: 100%
 }
+

--- a/public/stylesheets/taas.css
+++ b/public/stylesheets/taas.css
@@ -1,0 +1,28 @@
+/*
+	Remove inherited float style form HMRC from .content__body which breaks layout of back button
+	https://github.com/hmrc/assets-frontend/blob/3610585baeb96bb4ad9d73d20cfb73864e095b50/assets/scss/layouts/_page.scss#L59
+
+	There are plans to update and remove .content__body styles, but until then we need this fix in place.
+*/
+
+@media (min-width: 641px) {
+	.content__body {
+	    float: none;
+	}
+}
+
+/* ---- Get help with this page link over rides ---- */
+
+.report-error .report-error__toggle {
+	font-size: 16px;
+}
+
+@media (min-width: 641px) {
+	.report-error .report-error__toggle {
+		font-size: 19px;
+	}
+}
+
+.report-error {
+	margin-top: 0;
+}


### PR DESCRIPTION
A move to uplift to AF v3, which is a slow move towards eventually
moving away from AF all together.

As part of the work running through the app to see how AF v3 affects
the service layout I updated and fixed a couple of features like the
back button, spacing and font sizing around the continue button and
spacing on summary page continue button.

### Before
<img width="1440" alt="screen shot 2018-01-15 at 10 16 13" src="https://user-images.githubusercontent.com/1692222/34938286-ae700640-f9df-11e7-94da-c8e998acb373.png">

### After
<img width="1440" alt="screen shot 2018-01-15 at 10 14 19" src="https://user-images.githubusercontent.com/1692222/34938294-b9835e60-f9df-11e7-94e4-d93e59889865.png">
