### PR TITLE
[SCRS-11082]: fix to check case insensitive for officer former name

### DIFF
--- a/app/features/officer/forms/OfficerForms.scala
+++ b/app/features/officer/forms/OfficerForms.scala
@@ -79,7 +79,7 @@ object FormerNameForm {
 
   def isNotMatchingCompletionCapacityId(matcher: String, errorMsg: String): Constraint[String] = Constraint[String] {
     input: String =>
-      if (matcher != input.replaceAll(" ", "")) Valid else Invalid(errorMsg)
+      if (matcher.toLowerCase != input.replaceAll(" ", "").toLowerCase) Valid else Invalid(errorMsg)
   }
 
   def form(completionCapacityId: String) = Form(

--- a/test/features/officer/forms/OfficerFormsSpec.scala
+++ b/test/features/officer/forms/OfficerFormsSpec.scala
@@ -217,6 +217,16 @@ class OfficerFormsSpec extends UnitSpec {
       boundForm shouldHaveErrors Seq("formerName" -> "validation.formerName.match.cc")
     }
 
+    "have the correct error if true is selected and the name provided is same as the completion capacity (case insensitive)" in {
+      val data = Map(
+        "formerNameRadio" -> "true",
+        "formerName" -> "test current name"
+      )
+      val boundForm = testForm.bind(data)
+
+      boundForm shouldHaveErrors Seq("formerName" -> "validation.formerName.match.cc")
+    }
+
     "Unbind successfully with true and valid name" in {
       val data = Map(
         "formerNameRadio" -> "true",


### PR DESCRIPTION
# SCRS-11082 - fix to check case insensitive for officer former name

**Bug fix**

Add the check on officer former name to be case insensitive.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message

