### PR TITLE
revert assets frontend to 3.0.2 to no break existing timeout dialog

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,7 +60,7 @@ play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
 //play.crypto.secret="yIFxaTxyLz5Fwh7oVZbNKwPfNUbkZc0FmCU8ulrziNTngOrLzsWVwwnOZ4jxYMmp"
 
 assets {
-  version = "3.3.2"
+  version = "3.0.2"
   version = ${?ASSETS_FRONTEND_VERSION}
   url     = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
# Revert ASSETS_FRONTEND version

**Bug fix**

Revert ASSETS FRONTEND back to 3.0.2 to not break the current timeout dialog.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
