### PR TITLE
SAR-8011 Updated the business entity model rules and integrated with a new service

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -38,6 +38,7 @@ trait AppConfig {
   val contactFrontendUrl: String
 }
 
+// scalastyle:off
 @Singleton
 class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, runModeConfiguration: Configuration) extends AppConfig with FeatureSwitching {
 
@@ -200,13 +201,6 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, runModeCon
       s"$partnershipIdHost/partnership-identification/api/general-partnership/journey"
     }
 
-  def startTrustJourneyUrl: String =
-    if (isEnabled(StubPartnershipIdentification)) {
-      s"$host/register-for-vat/test-only/partnership-identification?partyType=${PartyType.stati(Trust)}"
-    } else {
-      s"$partnershipIdHost/partnership-identification/api/trust/journey"
-    }
-
   def getPartnershipIdDetailsUrl(journeyId: String): String =
     if (isEnabled(StubPartnershipIdentification)) {
       s"$host/register-for-vat/test-only/partnership-identification/$journeyId"
@@ -215,6 +209,33 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, runModeCon
     }
 
   def partnershipIdCallbackUrl: String = s"$hostUrl/register-for-vat/partnership-id-callback"
+
+  // Business Identification Section
+
+  lazy val businessIdHost: String = servicesConfig.baseUrl("business-identification-frontend")
+
+  def startUnincorpAssocJourneyUrl: String =
+    if (isEnabled(StubBusinessIdentification)) {
+      s"$host/register-for-vat/test-only/business-identification?partyType=${PartyType.stati(UnincorpAssoc)}"
+    } else {
+      s"$businessIdHost/business-identification/api/unincorporated-association/journey"
+    }
+
+  def startTrustJourneyUrl: String =
+    if (isEnabled(StubBusinessIdentification)) {
+      s"$host/register-for-vat/test-only/business-identification?partyType=${PartyType.stati(Trust)}"
+    } else {
+      s"$businessIdHost/business-identification/api/trust/journey"
+    }
+
+  def getBusinessIdDetailsUrl(journeyId: String): String =
+    if (isEnabled(StubBusinessIdentification)) {
+      s"$host/register-for-vat/test-only/business-identification/$journeyId"
+    } else {
+      s"$businessIdHost/business-identification/api/journey/$journeyId"
+    }
+
+  def businessIdCallbackUrl: String = s"$hostUrl/register-for-vat/business-id-callback"
 
   // Email Verification Section
 

--- a/app/connectors/S4LConnector.scala
+++ b/app/connectors/S4LConnector.scala
@@ -16,21 +16,21 @@
 
 package connectors
 
-import javax.inject.{Inject, Singleton}
-import play.api.libs.json.Format
+import play.api.libs.json.{Reads, Writes}
 import uk.gov.hmrc.http.cache.client.{CacheMap, ShortLivedCache}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class S4LConnector @Inject()(val shortCache: ShortLivedCache)
                             (implicit ec: ExecutionContext) {
 
-  def save[T](Id: String, formId: String, data: T)(implicit hc: HeaderCarrier, format: Format[T]): Future[CacheMap] =
+  def save[T](Id: String, formId: String, data: T)(implicit hc: HeaderCarrier, writes: Writes[T]): Future[CacheMap] =
     shortCache.cache[T](Id, formId, data)
 
-  def fetchAndGet[T](Id: String, formId: String)(implicit hc: HeaderCarrier, format: Format[T]): Future[Option[T]] =
+  def fetchAndGet[T](Id: String, formId: String)(implicit hc: HeaderCarrier, reads: Reads[T]): Future[Option[T]] =
     shortCache.fetchAndGetEntry[T](Id, formId)
 
   def clear(Id: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = shortCache.remove(Id)

--- a/app/connectors/VatRegistrationConnector.scala
+++ b/app/connectors/VatRegistrationConnector.scala
@@ -78,8 +78,9 @@ class VatRegistrationConnector @Inject()(val http: HttpClient,
     }
   }
 
-  def getApplicantDetails(regId: String)(implicit hc: HeaderCarrier): Future[Option[ApplicantDetails]] = {
-    implicit val reads: Reads[ApplicantDetails] = ApplicantDetails.apiReads
+  def getApplicantDetails(regId: String, partyType: PartyType)(implicit hc: HeaderCarrier): Future[Option[ApplicantDetails]] = {
+    implicit val reads: Reads[ApplicantDetails] = ApplicantDetails.reads(partyType)
+
     http.GET[Option[ApplicantDetails]](s"$vatRegUrl/vatreg/$regId/applicant-details").recover {
       case e => throw logResponse(e, "getApplicantDetails")
     }
@@ -94,7 +95,7 @@ class VatRegistrationConnector @Inject()(val http: HttpClient,
   }
 
   def patchApplicantDetails(data: ApplicantDetails)(implicit profile: CurrentProfile, hc: HeaderCarrier): Future[JsValue] = {
-    val json = Json.toJson(data)(ApplicantDetails.apiWrites).as[JsObject]
+    val json = Json.toJson(data)(ApplicantDetails.writes).as[JsObject]
     http.PATCH[JsValue, JsValue](s"$vatRegUrl/vatreg/${profile.registrationId}/applicant-details", json) map {
       _ => json
     } recover {

--- a/app/controllers/HonestyDeclarationController.scala
+++ b/app/controllers/HonestyDeclarationController.scala
@@ -55,8 +55,10 @@ class HonestyDeclarationController @Inject()(honestyDeclarationView: honesty_dec
               Redirect(applicantRoutes.SoleTraderIdentificationController.startJourney())
             case UkCompany | RegSociety | CharitableOrg =>
               Redirect(applicantRoutes.IncorpIdController.startJourney())
-            case Partnership | Trust =>
+            case Partnership =>
               Redirect(applicantRoutes.PartnershipIdController.startJourney())
+            case UnincorpAssoc | Trust =>
+              Redirect(applicantRoutes.BusinessIdController.startJourney())
           }
         }
   }

--- a/app/controllers/TradingNameResolverController.scala
+++ b/app/controllers/TradingNameResolverController.scala
@@ -40,7 +40,7 @@ class TradingNameResolverController @Inject()(val keystoreConnector: KeystoreCon
     implicit request =>
       implicit profile =>
         vatRegistrationService.partyType map {
-          case Individual | Partnership | Trust => Redirect(controllers.registration.business.routes.MandatoryTradingNameController.show())
+          case Individual | Partnership | Trust | UnincorpAssoc => Redirect(controllers.registration.business.routes.MandatoryTradingNameController.show())
           case UkCompany | RegSociety | CharitableOrg => Redirect(controllers.registration.business.routes.TradingNameController.show())
           case pt => throw new InternalServerException(s"PartyType: $pt not supported")
         }

--- a/app/controllers/registration/applicant/SoleTraderIdentificationController.scala
+++ b/app/controllers/registration/applicant/SoleTraderIdentificationController.scala
@@ -66,7 +66,7 @@ class SoleTraderIdentificationController @Inject()(val keystoreConnector: Keysto
         } yield {
           partyType match {
             case Individual => Redirect(applicantRoutes.FormerNameController.show())
-            case UkCompany | RegSociety | CharitableOrg | Trust => Redirect(applicantRoutes.CaptureRoleInTheBusinessController.show())
+            case UkCompany | RegSociety | CharitableOrg | Trust | UnincorpAssoc => Redirect(applicantRoutes.CaptureRoleInTheBusinessController.show())
             case _ => throw new IllegalStateException("PartyType not supported")
           }
         }

--- a/app/controllers/test/BusinessIdentificationStubController.scala
+++ b/app/controllers/test/BusinessIdentificationStubController.scala
@@ -16,9 +16,9 @@
 
 package controllers.test
 
-import models.api.{Partnership, PartyType, Trust}
-import models.external.partnershipid.PartnershipIdJourneyConfig
-import models.external.{BvPass, PartnershipIdEntity}
+import models.api.{PartyType, Trust, UnincorpAssoc}
+import models.external.businessid.BusinessIdJourneyConfig
+import models.external.{BusinessIdEntity, BvPass}
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -27,12 +27,13 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
-class PartnershipIdentificationStubController @Inject()(mcc: MessagesControllerComponents) extends FrontendController(mcc) {
+class BusinessIdentificationStubController @Inject()(mcc: MessagesControllerComponents) extends FrontendController(mcc) {
 
-  def createJourney(partyType: String): Action[PartnershipIdJourneyConfig] = Action(parse.json[PartnershipIdJourneyConfig]) {
+  def createJourney(partyType: String): Action[BusinessIdJourneyConfig] = Action(parse.json[BusinessIdJourneyConfig]) {
     journeyConfig =>
       val journeyId = PartyType.fromString(partyType) match {
-        case Partnership => "1"
+        case UnincorpAssoc => "1"
+        case Trust => "2"
       }
 
       Created(Json.obj("journeyStartUrl" -> JsString(journeyConfig.body.continueUrl + s"?journeyId=$journeyId")))
@@ -40,14 +41,16 @@ class PartnershipIdentificationStubController @Inject()(mcc: MessagesControllerC
 
   def retrieveValidationResult(journeyId: String): Action[AnyContent] = Action.async {
     Future.successful(
-      Ok(Json.toJson(PartnershipIdEntity(
+      Ok(Json.toJson(BusinessIdEntity(
         sautr = Some("1234567890"),
-        postCode = if (journeyId.equals("1")) Some("AA11AA") else None,
+        postCode = Some("AA11AA"),
+        chrn = Some("1234567890"),
+        casc = if (journeyId.equals("1")) Some("1234567890") else None,
         registration = "REGISTERED",
         businessVerification = BvPass,
         bpSafeId = Some("testBpId"),
         identifiersMatch = true
-      ))(PartnershipIdEntity.apiFormat))
+      ))(BusinessIdEntity.apiFormat))
     )
   }
 

--- a/app/controllers/test/IncorpIdApiStubController.scala
+++ b/app/controllers/test/IncorpIdApiStubController.scala
@@ -51,8 +51,8 @@ class IncorpIdApiStubController @Inject()(mcc: MessagesControllerComponents)
         chrn = if (journeyId.equals("3")) Some("123567890") else None,
         dateOfIncorporation = LocalDate.of(2020, 1, 1),
         identifiersMatch = true,
-        registration = Some("REGISTERED"),
-        businessVerification = Some(BvPass),
+        registration = "REGISTERED",
+        businessVerification = BvPass,
         bpSafeId = Some("testBpId")
       ))(IncorporatedEntity.apiFormat))
     )

--- a/app/featureswitch/core/config/FeatureSwitchingModule.scala
+++ b/app/featureswitch/core/config/FeatureSwitchingModule.scala
@@ -33,6 +33,7 @@ class FeatureSwitchingModule extends Module with FeatureSwitchRegistry {
     StubUpscan,
     StubBars,
     StubPartnershipIdentification,
+    StubBusinessIdentification,
     TrafficManagementPredicate,
     UseSoleTraderIdentification,
     UseUpscan,
@@ -85,6 +86,11 @@ case object StubBars extends FeatureSwitch {
 case object StubPartnershipIdentification extends FeatureSwitch {
   val configName = "feature-switch.partnership-identification"
   val displayName = "Stub Partnership Identification"
+}
+
+case object StubBusinessIdentification extends FeatureSwitch {
+  val configName = "feature-switch.business-identification"
+  val displayName = "Stub Business Identification"
 }
 
 case object TrafficManagementPredicate extends FeatureSwitch {

--- a/app/models/PartnerEntity.scala
+++ b/app/models/PartnerEntity.scala
@@ -18,6 +18,7 @@ package models
 
 import models.api.PartyType
 import models.external.BusinessEntity
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 case class PartnerEntity(details: BusinessEntity,
@@ -25,5 +26,17 @@ case class PartnerEntity(details: BusinessEntity,
                          isLeadPartner: Boolean)
 
 object PartnerEntity {
-  implicit val format: Format[PartnerEntity] = Json.format[PartnerEntity]
+  val reads: Reads[PartnerEntity] =
+    (__ \ "partyType").read[PartyType].flatMap { partyType =>
+      (
+        (__ \ "details").read[BusinessEntity](BusinessEntity.reads(partyType)) and
+        Reads.pure(partyType) and
+        (__ \ "isLeadPartner").read[Boolean]
+      )(PartnerEntity.apply _)
+    }
+
+  val writes: OWrites[PartnerEntity] = Json.writes[PartnerEntity]
+
+  implicit val format: Format[PartnerEntity] = Format(reads, writes)
+
 }

--- a/app/models/api/VatScheme.scala
+++ b/app/models/api/VatScheme.scala
@@ -17,8 +17,8 @@
 package models.api
 
 import common.enums.VatRegStatus
-import models.{ApplicantDetails, _}
 import models.api.returns.Returns
+import models.{ApplicantDetails, _}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -28,40 +28,58 @@ case class VatScheme(id: String,
                      sicAndCompliance: Option[SicAndCompliance] = None,
                      businessContact: Option[BusinessContact] = None,
                      returns: Option[Returns] = None,
-                     bankAccount : Option[BankAccount] = None,
+                     bankAccount: Option[BankAccount] = None,
                      flatRateScheme: Option[FlatRateScheme] = None,
                      status: VatRegStatus.Value,
                      eligibilitySubmissionData: Option[EligibilitySubmissionData] = None,
                      partners: Option[List[PartnerEntity]] = None)
 
 object VatScheme {
-  val s4lFormat: Format[VatScheme] = (
-    (__ \ "registrationId").format[String] and
-    (__ \ ApplicantDetails.s4lKey.key).formatNullable[ApplicantDetails] and
-    (__ \ TradingDetails.s4lKey.key).formatNullable[TradingDetails] and
-    (__ \ SicAndCompliance.s4lKey.key).formatNullable[SicAndCompliance]
-      .inmap[Option[SicAndCompliance]](_ => Option.empty[SicAndCompliance], _ => Option.empty[SicAndCompliance]) and
-    (__ \ BusinessContact.s4lKey.key).formatNullable[BusinessContact] and
-    (__ \ Returns.s4lKey.key).formatNullable[Returns] and
-    (__ \ BankAccount.s4lKey.key).formatNullable[BankAccount] and
-    (__ \ FlatRateScheme.s4lKey.key).formatNullable[FlatRateScheme] and
-    (__ \ "status").format[VatRegStatus.Value] and
-    (__ \ "eligibilitySubmissionData").formatNullable[EligibilitySubmissionData] and
-    (__ \ "partners").formatNullable[List[PartnerEntity]]
-  )(VatScheme.apply, unlift(VatScheme.unapply))
 
-  implicit val format: OFormat[VatScheme] = (
-      (__ \ "registrationId").format[String] and
-      (__ \ "applicantDetails").formatNullable[ApplicantDetails](ApplicantDetails.apiFormat) and
-      (__ \ "tradingDetails").formatNullable[TradingDetails](TradingDetails.apiFormat) and
-      (__ \ "sicAndCompliance").formatNullable[SicAndCompliance](SicAndCompliance.apiFormat)
-        .inmap[Option[SicAndCompliance]](_ => Option.empty[SicAndCompliance], _ => Option.empty[SicAndCompliance]) and
-      (__ \ "businessContact").formatNullable[BusinessContact](BusinessContact.apiFormat) and
-      (__ \ "returns").formatNullable[Returns] and
-      (__ \ "bankAccount").formatNullable[BankAccount] and
-      (__ \ "flatRateScheme").formatNullable[FlatRateScheme](FlatRateScheme.apiFormat) and
-      (__ \ "status").format[VatRegStatus.Value] and
-      (__ \ "eligibilitySubmissionData").formatNullable[EligibilitySubmissionData] and
-      (__ \ "partners").formatNullable[List[PartnerEntity]]
-    )(VatScheme.apply, unlift(VatScheme.unapply))
+  val reads: Reads[VatScheme] =
+    (__ \ "eligibilitySubmissionData" \ "partyType").readNullable[PartyType].flatMap {
+      case Some(partyType) => (
+        (__ \ "registrationId").read[String] and
+          (__ \ "applicantDetails").readNullable[ApplicantDetails](ApplicantDetails.reads(partyType)) and
+          (__ \ "tradingDetails").readNullable[TradingDetails](TradingDetails.apiFormat) and
+          (__ \ "sicAndCompliance").readNullable[SicAndCompliance](SicAndCompliance.apiFormat) and
+          (__ \ "businessContact").readNullable[BusinessContact](BusinessContact.apiFormat) and
+          (__ \ "returns").readNullable[Returns] and
+          (__ \ "bankAccount").readNullable[BankAccount] and
+          (__ \ "flatRateScheme").readNullable[FlatRateScheme](FlatRateScheme.apiFormat) and
+          (__ \ "status").read[VatRegStatus.Value] and
+          (__ \ "eligibilitySubmissionData").readNullable[EligibilitySubmissionData] and
+          (__ \ "partners").readNullable[List[PartnerEntity]]
+        ) (VatScheme.apply _)
+      case None => (
+        (__ \ "registrationId").read[String] and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          Reads.pure(None) and
+          (__ \ "status").read[VatRegStatus.Value] and
+          Reads.pure(None) and
+          Reads.pure(None)
+        ) (VatScheme.apply _)
+    }
+
+  val writes: Writes[VatScheme] = (
+    (__ \ "registrationId").write[String] and
+      (__ \ "applicantDetails").writeNullable[ApplicantDetails](ApplicantDetails.writes) and
+      (__ \ "tradingDetails").writeNullable[TradingDetails](TradingDetails.apiFormat) and
+      (__ \ "sicAndCompliance").writeNullable[SicAndCompliance](SicAndCompliance.apiFormat) and
+      (__ \ "businessContact").writeNullable[BusinessContact](BusinessContact.apiFormat) and
+      (__ \ "returns").writeNullable[Returns] and
+      (__ \ "bankAccount").writeNullable[BankAccount] and
+      (__ \ "flatRateScheme").writeNullable[FlatRateScheme](FlatRateScheme.apiFormat) and
+      (__ \ "status").write[VatRegStatus.Value] and
+      (__ \ "eligibilitySubmissionData").writeNullable[EligibilitySubmissionData] and
+      (__ \ "partners").writeNullable[List[PartnerEntity]]
+    ) (unlift(VatScheme.unapply))
+
+  implicit val format: Format[VatScheme] = Format(reads, writes)
+
 }

--- a/app/models/external/BusinessEntity.scala
+++ b/app/models/external/BusinessEntity.scala
@@ -16,25 +16,32 @@
 
 package models.external
 
+import models.api._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.http.InternalServerException
 
 import java.time.LocalDate
 
 sealed trait BusinessEntity
 
 object BusinessEntity {
-  val reads: Reads[BusinessEntity] = Reads { json =>
-    Json.fromJson(json)(IncorporatedEntity.format).orElse(Json.fromJson(json)(SoleTrader.format)).orElse(Json.fromJson(json)(PartnershipIdEntity.format))
+  def reads(partyType: PartyType): Reads[BusinessEntity] = Reads { json =>
+    partyType match {
+      case UkCompany | RegSociety | CharitableOrg => Json.fromJson(json)(IncorporatedEntity.format)
+      case Individual => Json.fromJson(json)(SoleTrader.format)
+      case Partnership => Json.fromJson(json)(PartnershipIdEntity.format)
+      case UnincorpAssoc | Trust => Json.fromJson(json)(BusinessIdEntity.format)
+      case _ => throw new InternalServerException("Tried to parse business entity for an unsupported party type")
+    }
   }
 
-  val writes: Writes[BusinessEntity] = Writes {
+  implicit val writes: Writes[BusinessEntity] = Writes {
     case incorporatedEntity: IncorporatedEntity => Json.toJson(incorporatedEntity)
     case soleTrader: SoleTrader => Json.toJson(soleTrader)
-    case generalPartnership: PartnershipIdEntity => Json.toJson(generalPartnership)
+    case partnershipIdEntity: PartnershipIdEntity => Json.toJson(partnershipIdEntity)
+    case businessIdEntity: BusinessIdEntity => Json.toJson(businessIdEntity)
   }
-
-  implicit val format: Format[BusinessEntity] = Format[BusinessEntity](reads, writes)
 }
 
 case class IncorporatedEntity(companyNumber: String,
@@ -44,38 +51,23 @@ case class IncorporatedEntity(companyNumber: String,
                               dateOfIncorporation: LocalDate,
                               countryOfIncorporation: String = "GB",
                               identifiersMatch: Boolean,
-                              registration: Option[String] = None,
-                              businessVerification: Option[BusinessVerificationStatus] = None,
-                              bpSafeId: Option[String] = None) extends BusinessEntity
+                              registration: String,
+                              businessVerification: BusinessVerificationStatus,
+                              bpSafeId: Option[String]) extends BusinessEntity
 
 object IncorporatedEntity {
-  val apiReads: Reads[IncorporatedEntity] = (
-    (__ \ "companyProfile" \ "companyNumber").read[String] and
-      (__ \ "companyProfile" \ "companyName").read[String] and
-      (__ \ "ctutr").readNullable[String] and
-      (__ \ "chrn").readNullable[String] and
-      (__ \ "companyProfile" \ "dateOfIncorporation").read[LocalDate] and
-      Reads.pure("GB") and
-      (__ \ "identifiersMatch").read[Boolean] and
-      (__ \ "registration" \ "registrationStatus").readNullable[String].orElse(Reads.pure(None)) and
-      (__ \ "businessVerification" \ "verificationStatus").readNullable[BusinessVerificationStatus].orElse(Reads.pure(None)) and
-      (__ \ "registration" \ "registeredBusinessPartnerId").readNullable[String].orElse(Reads.pure(None))
-    ) (IncorporatedEntity.apply _)
-
-  val apiWrites: Writes[IncorporatedEntity] = (
-    (__ \ "companyProfile" \ "companyNumber").write[String] and
-      (__ \ "companyProfile" \ "companyName").write[String] and
-      (__ \ "ctutr").writeNullable[String] and
-      (__ \ "chrn").writeNullable[String] and
-      (__ \ "companyProfile" \ "dateOfIncorporation").write[LocalDate] and
-      (__ \ "companyProfile" \ "countryOfIncorporation").write[String] and
-      (__ \ "identifiersMatch").write[Boolean] and
-      (__ \ "registration" \ "registrationStatus").writeNullable[String] and
-      (__ \ "businessVerification" \ "verificationStatus").writeNullable[BusinessVerificationStatus] and
-      (__ \ "registration" \ "registeredBusinessPartnerId").writeNullable[String]
-    ) (unlift(IncorporatedEntity.unapply))
-
-  val apiFormat: Format[IncorporatedEntity] = Format[IncorporatedEntity](apiReads, apiWrites)
+  val apiFormat: Format[IncorporatedEntity] = (
+    (__ \ "companyProfile" \ "companyNumber").format[String] and
+      (__ \ "companyProfile" \ "companyName").format[String] and
+      (__ \ "ctutr").formatNullable[String] and
+      (__ \ "chrn").formatNullable[String] and
+      (__ \ "companyProfile" \ "dateOfIncorporation").format[LocalDate] and
+      OFormat(Reads.pure("GB"), (__ \ "companyProfile" \ "countryOfIncorporation").write[String]) and
+      (__ \ "identifiersMatch").format[Boolean] and
+      (__ \ "registration" \ "registrationStatus").format[String] and
+      (__ \ "businessVerification" \ "verificationStatus").format[BusinessVerificationStatus] and
+      (__ \ "registration" \ "registeredBusinessPartnerId").formatNullable[String]
+    ) (IncorporatedEntity.apply, unlift(IncorporatedEntity.unapply))
 
   implicit val format: Format[IncorporatedEntity] = Json.format[IncorporatedEntity]
 }
@@ -88,41 +80,26 @@ case class SoleTrader(firstName: String,
                       registration: String,
                       businessVerification: BusinessVerificationStatus,
                       bpSafeId: Option[String] = None,
-                      identifiersMatch: Boolean) extends BusinessEntity
+                      identifiersMatch: Boolean = true) extends BusinessEntity
 
 object SoleTrader {
-  val apiReads: Reads[SoleTrader] = (
-    (__ \ "fullName" \ "firstName").read[String] and
-      (__ \ "fullName" \ "lastName").read[String] and
-      (__ \ "dateOfBirth").read[LocalDate] and
-      (__ \ "nino").read[String] and
-      (__ \ "sautr").readNullable[String] and
-      (__ \ "registration" \ "registrationStatus").read[String] and
-      (__ \ "businessVerification" \ "verificationStatus").read[BusinessVerificationStatus] and
-      (__ \ "registration" \ "registeredBusinessPartnerId").readNullable[String].orElse(Reads.pure(None)) and
-      (__ \ "identifiersMatch").read[Boolean].orElse(Reads.pure(true))
-    ) (SoleTrader.apply _)
-
-  val apiWrites: Writes[SoleTrader] = (
-    (__ \ "fullName" \ "firstName").write[String] and
-      (__ \ "fullName" \ "lastName").write[String] and
-      (__ \ "dateOfBirth").write[LocalDate] and
-      (__ \ "nino").write[String] and
-      (__ \ "sautr").writeNullable[String] and
-      (__ \ "registration" \ "registrationStatus").write[String] and
-      (__ \ "businessVerification" \ "verificationStatus").write[BusinessVerificationStatus] and
-      (__ \ "registration" \ "registeredBusinessPartnerId").writeNullable[String] and
-      (__ \ "identifiersMatch").write[Boolean]
-    ) (unlift(SoleTrader.unapply))
-
-  val apiFormat: Format[SoleTrader] = Format[SoleTrader](apiReads, apiWrites)
+  val apiFormat: Format[SoleTrader] = (
+    (__ \ "fullName" \ "firstName").format[String] and
+      (__ \ "fullName" \ "lastName").format[String] and
+      (__ \ "dateOfBirth").format[LocalDate] and
+      (__ \ "nino").format[String] and
+      (__ \ "sautr").formatNullable[String] and
+      (__ \ "registration" \ "registrationStatus").format[String] and
+      (__ \ "businessVerification" \ "verificationStatus").format[BusinessVerificationStatus] and
+      (__ \ "registration" \ "registeredBusinessPartnerId").formatNullable[String] and
+      OFormat((__ \ "identifiersMatch").read[Boolean].orElse(Reads.pure(true)), (__ \ "identifiersMatch").write[Boolean])
+    ) (SoleTrader.apply, unlift(SoleTrader.unapply))
 
   implicit val format: Format[SoleTrader] = Json.format[SoleTrader]
 }
 
 case class PartnershipIdEntity(sautr: Option[String],
                                postCode: Option[String],
-                               chrn: Option[String],
                                registration: String,
                                businessVerification: BusinessVerificationStatus,
                                bpSafeId: Option[String] = None,
@@ -133,7 +110,6 @@ object PartnershipIdEntity {
   val apiFormat: Format[PartnershipIdEntity] = (
     (__ \ "sautr").formatNullable[String] and
       (__ \ "postcode").formatNullable[String] and
-      (__ \ "chrn").formatNullable[String] and
       (__ \ "registration" \ "registrationStatus").format[String] and
       (__ \ "businessVerification" \ "verificationStatus").format[BusinessVerificationStatus] and
       (__ \ "registration" \ "registeredBusinessPartnerId").formatNullable[String] and
@@ -143,3 +119,30 @@ object PartnershipIdEntity {
   implicit val format: Format[PartnershipIdEntity] = Json.format[PartnershipIdEntity]
 
 }
+
+case class BusinessIdEntity(sautr: Option[String],
+                            postCode: Option[String],
+                            chrn: Option[String],
+                            casc: Option[String],
+                            registration: String,
+                            businessVerification: BusinessVerificationStatus,
+                            bpSafeId: Option[String] = None,
+                            identifiersMatch: Boolean) extends BusinessEntity
+
+object BusinessIdEntity {
+
+  val apiFormat: Format[BusinessIdEntity] = (
+    (__ \ "sautr").formatNullable[String] and
+      (__ \ "postcode").formatNullable[String] and
+      (__ \ "chrn").formatNullable[String] and
+      (__ \ "casc").formatNullable[String] and
+      (__ \ "registration" \ "registrationStatus").format[String] and
+      (__ \ "businessVerification" \ "verificationStatus").format[BusinessVerificationStatus] and
+      (__ \ "registration" \ "registeredBusinessPartnerId").formatNullable[String] and
+      (__ \ "identifiersMatch").format[Boolean]
+    ) (BusinessIdEntity.apply, unlift(BusinessIdEntity.unapply))
+
+  implicit val format: Format[BusinessIdEntity] = Json.format[BusinessIdEntity]
+
+}
+

--- a/app/models/external/businessid/BusinessIdJourneyConfig.scala
+++ b/app/models/external/businessid/BusinessIdJourneyConfig.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.external.businessid
+
+import play.api.libs.json.{Json, OFormat}
+
+case class BusinessIdJourneyConfig(continueUrl: String, optServiceName: Option[String] = None, deskProServiceId: String, signOutUrl: String)
+
+object BusinessIdJourneyConfig {
+  implicit val format: OFormat[BusinessIdJourneyConfig] = Json.format[BusinessIdJourneyConfig]
+}

--- a/app/services/BusinessIdService.scala
+++ b/app/services/BusinessIdService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.BusinessIdConnector
+import models.api.PartyType
+import models.external.BusinessIdEntity
+import models.external.businessid.BusinessIdJourneyConfig
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+@Singleton
+class BusinessIdService @Inject()(businessIdConnector: BusinessIdConnector) {
+
+  def createJourney(journeyConfig: BusinessIdJourneyConfig, partyType: PartyType)(implicit hc: HeaderCarrier): Future[String] = {
+    businessIdConnector.createJourney(journeyConfig, partyType)
+  }
+
+  def getDetails(journeyId: String)(implicit hc: HeaderCarrier): Future[BusinessIdEntity] = {
+    businessIdConnector.getDetails(journeyId)
+  }
+
+}

--- a/app/services/S4LService.scala
+++ b/app/services/S4LService.scala
@@ -29,10 +29,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class S4LService @Inject()(val s4LConnector: S4LConnector)
                           (implicit executionContext: ExecutionContext) {
 
-  def save[T: S4LKey](data: T)(implicit profile: CurrentProfile, hc: HeaderCarrier, format: Format[T]): Future[CacheMap] =
+  def save[T: S4LKey](data: T)(implicit profile: CurrentProfile, hc: HeaderCarrier, writes: Writes[T]): Future[CacheMap] =
     s4LConnector.save[T](profile.registrationId, S4LKey[T].key, data)
 
-  def fetchAndGet[T: S4LKey](implicit profile: CurrentProfile, hc: HeaderCarrier, format: Format[T]): Future[Option[T]] =
+  def fetchAndGet[T: S4LKey](implicit profile: CurrentProfile, hc: HeaderCarrier, reads: Reads[T]): Future[Option[T]] =
     s4LConnector.fetchAndGet[T](profile.registrationId, S4LKey[T].key).recover {
       case _: JsResultException => None
     }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -155,9 +155,13 @@ GET         /sti-callback                                                       
 GET         /start-sti-partner-journey                                                         controllers.registration.applicant.SoleTraderIdentificationController.startPartnerJourney(isLeadPartner: Boolean)
 GET         /sti-partner-callback/:isLeadPartner                                               controllers.registration.applicant.SoleTraderIdentificationController.partnerCallback(isLeadPartner: Boolean, journeyId: String)
 
-## Incorp ID Pages
+## Partnership ID Pages
 GET         /start-partnership-id-journey                                                      controllers.registration.applicant.PartnershipIdController.startJourney()
 GET         /partnership-id-callback                                                           controllers.registration.applicant.PartnershipIdController.callback(journeyId)
+
+## Business ID Pages
+GET         /start-business-id-journey                                                         controllers.registration.applicant.BusinessIdController.startJourney()
+GET         /business-id-callback                                                              controllers.registration.applicant.BusinessIdController.callback(journeyId)
 
 ## Email Verification Pages
 GET         /email-address                                                                     controllers.registration.applicant.CaptureEmailAddressController.show

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -246,6 +246,12 @@ microservice {
       url = "http://localhost:9722"
     }
 
+    business-identification-frontend {
+      host = localhost
+      port = 9722
+      url = "http://localhost:9722"
+    }
+
     personal-details-validation {
       host = localhost
       port = 9967

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -37,6 +37,10 @@ POST        /partnership-identification                       controllers.test.P
 GET         /partnership-identification/:journeyId            controllers.test.PartnershipIdentificationStubController.retrieveValidationResult(journeyId)
 
 + nocsrf
+POST        /business-identification                          controllers.test.BusinessIdentificationStubController.createJourney(partyType: String)
+GET         /business-identification/:journeyId               controllers.test.BusinessIdentificationStubController.retrieveValidationResult(journeyId)
+
++ nocsrf
 POST        /api/request-passcode                             controllers.test.EmailVerificationStubController.requestEmailVerificationPasscode
 
 + nocsrf

--- a/it/connectors/BusinessIdConnectorISpec.scala
+++ b/it/connectors/BusinessIdConnectorISpec.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import it.fixtures.ITRegistrationFixtures
+import itutil.IntegrationSpecBase
+import models.api.{Partnership, Trust, UnincorpAssoc}
+import models.external.businessid.BusinessIdJourneyConfig
+import models.external.{BusinessIdEntity, BusinessVerificationStatus, BvPass}
+import play.api.libs.json.{JsObject, JsResultException, Json}
+import play.api.test.Helpers.{CREATED, IM_A_TEAPOT, OK, UNAUTHORIZED, _}
+import support.AppAndStubs
+import uk.gov.hmrc.http.InternalServerException
+
+class BusinessIdConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITRegistrationFixtures {
+
+  val testUnincorpAssocJourneyId = "1"
+  val testTrustJourneyId = "2"
+  val testJourneyUrl = "/test-journey-url"
+  val createTrustJourneyUrl = "/business-identification/api/trust/journey"
+  val createUnincorpAssocJourneyUrl = "/business-identification/api/unincorporated-association/journey"
+
+  def retrieveDetailsUrl(journeyId: String) = s"/business-identification/api/journey/$journeyId"
+
+  val connector: BusinessIdConnector = app.injector.instanceOf[BusinessIdConnector]
+
+  val testJourneyConfig: BusinessIdJourneyConfig = BusinessIdJourneyConfig(
+    continueUrl = "/test-url",
+    optServiceName = Some("MTD"),
+    deskProServiceId = "MTDSUR",
+    signOutUrl = "/test-sign-out"
+  )
+
+  val testPostCode = "ZZ1 1ZZ"
+
+  val testTrustResponse: JsObject = Json.obj(
+    "sautr" -> testSautr,
+    "postcode" -> testPostCode,
+    "chrn" -> testChrn,
+    "businessVerification" -> Json.obj(
+      "verificationStatus" -> Json.toJson[BusinessVerificationStatus](BvPass)
+    ),
+    "registration" -> Json.obj(
+      "registrationStatus" -> testRegistration,
+      "registeredBusinessPartnerId" -> testSafeId
+    ),
+    "identifiersMatch" -> true
+  )
+
+  val testTrust: BusinessIdEntity = BusinessIdEntity(
+    Some(testSautr),
+    Some(testPostCode),
+    Some(testChrn),
+    None,
+    testRegistration,
+    BvPass,
+    Some(testSafeId),
+    identifiersMatch = true
+  )
+
+  val testUnincorpAssocResponse: JsObject = Json.obj(
+    "sautr" -> testSautr,
+    "postcode" -> testPostCode,
+    "chrn" -> testChrn,
+    "casc" -> testCasc,
+    "businessVerification" -> Json.obj(
+      "verificationStatus" -> Json.toJson[BusinessVerificationStatus](BvPass)
+    ),
+    "registration" -> Json.obj(
+      "registrationStatus" -> testRegistration,
+      "registeredBusinessPartnerId" -> testSafeId
+    ),
+    "identifiersMatch" -> true
+  )
+
+  val testUnincorpAssoc: BusinessIdEntity = BusinessIdEntity(
+    Some(testSautr),
+    Some(testPostCode),
+    Some(testChrn),
+    Some(testCasc),
+    testRegistration,
+    BvPass,
+    Some(testSafeId),
+    identifiersMatch = true
+  )
+
+  "createJourney" when {
+    "the API returns CREATED" must {
+      "return the journey ID when the response JSON includes the journeyId for a Trust" in {
+        given()
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+
+        stubPost(createTrustJourneyUrl, CREATED, Json.stringify(Json.obj("journeyStartUrl" -> testJourneyUrl)))
+
+        val res = await(connector.createJourney(testJourneyConfig, Trust))
+
+        res mustBe testJourneyUrl
+      }
+
+      "return the journey ID when the response JSON includes the journeyId for a Unincorporated Association" in {
+        given()
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+
+        stubPost(createUnincorpAssocJourneyUrl, CREATED, Json.stringify(Json.obj("journeyStartUrl" -> testJourneyUrl)))
+
+        val res = await(connector.createJourney(testJourneyConfig, UnincorpAssoc))
+
+        res mustBe testJourneyUrl
+      }
+
+      "throw a JsResultException when the response JSON doesn't contain the journeyId" in {
+        given()
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+
+        stubPost(createTrustJourneyUrl, CREATED, "{}")
+
+        intercept[JsResultException] {
+          await(connector.createJourney(testJourneyConfig, Trust))
+        }
+      }
+    }
+
+    "the API returns an unexpected status" must {
+      "throw an InternalServerException" in new Setup {
+        given()
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+
+        stubPost(createUnincorpAssocJourneyUrl, UNAUTHORIZED, "")
+
+        intercept[InternalServerException] {
+          await(connector.createJourney(testJourneyConfig, Trust))
+        }
+      }
+    }
+  }
+
+  "getDetails" must {
+    "return trust when Business Id returns OK" in new Setup {
+      given()
+        .audit.writesAudit()
+        .audit.writesAuditMerged()
+
+      stubGet(retrieveDetailsUrl(testTrustJourneyId), OK, Json.stringify(testTrustResponse))
+      val res: BusinessIdEntity = await(connector.getDetails(testTrustJourneyId))
+
+      res mustBe testTrust
+    }
+
+    "return unincorporated association when Business Id returns OK" in new Setup {
+      given()
+        .audit.writesAudit()
+        .audit.writesAuditMerged()
+
+      stubGet(retrieveDetailsUrl(testUnincorpAssocJourneyId), OK, Json.stringify(testUnincorpAssocResponse))
+      val res: BusinessIdEntity = await(connector.getDetails(testUnincorpAssocJourneyId))
+
+      res mustBe testUnincorpAssoc
+    }
+
+    "throw an InternalServerException when relevant fields are missing OK" in new Setup {
+      given()
+        .audit.writesAudit()
+        .audit.writesAuditMerged()
+
+      val invalidTransactorJson: JsObject = testTrustResponse - "identifiersMatch"
+      stubGet(retrieveDetailsUrl(testTrustJourneyId), OK, Json.stringify(Json.obj("personalDetails" -> invalidTransactorJson)))
+
+      intercept[InternalServerException] {
+        await(connector.getDetails(testTrustJourneyId))
+      }
+    }
+
+    "throw an InternalServerException for any other status" in new Setup {
+      given()
+        .audit.writesAudit()
+        .audit.writesAuditMerged()
+
+      stubGet(retrieveDetailsUrl(testTrustJourneyId), IM_A_TEAPOT, "")
+
+      intercept[InternalServerException] {
+        await(connector.getDetails(testTrustJourneyId))
+      }
+    }
+  }
+}

--- a/it/connectors/IncorpIdConnectorISpec.scala
+++ b/it/connectors/IncorpIdConnectorISpec.scala
@@ -21,7 +21,7 @@ import it.fixtures.ITRegistrationFixtures
 import itutil.IntegrationSpecBase
 import models.api.{CharitableOrg, PartyType, RegSociety, UkCompany}
 import models.external.incorporatedentityid.IncorpIdJourneyConfig
-import models.external.{BvPass, IncorporatedEntity}
+import models.external.{BvFail, BvPass, IncorporatedEntity}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import support.AppAndStubs
@@ -152,7 +152,7 @@ class IncorpIdConnectorISpec extends IntegrationSpecBase with AppAndStubs with F
           .audit.writesAudit()
           .audit.writesAuditMerged()
 
-        val validResponse = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, identifiersMatch = false)
+        val validResponse = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, "GB", identifiersMatch = false, "REGISTRATION_FAILED", BvFail, None)
         disable(StubIncorpIdJourney)
         stubGet(s"/incorporated-entity-identification/api/journey/$testIncorpId", CREATED, Json.toJson(validResponse)(IncorporatedEntity.apiFormat).toString)
 
@@ -166,7 +166,7 @@ class IncorpIdConnectorISpec extends IntegrationSpecBase with AppAndStubs with F
           .audit.writesAudit()
           .audit.writesAuditMerged()
 
-        val validResponse = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, "GB", identifiersMatch = true, Some("REGISTERED"), Some(BvPass), Some(testBpSafeId))
+        val validResponse = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, "GB", identifiersMatch = true, "REGISTERED", BvPass, Some(testBpSafeId))
         disable(StubIncorpIdJourney)
         stubGet(s"/incorporated-entity-identification/api/journey/$testIncorpId", CREATED, Json.toJson(validResponse)(IncorporatedEntity.apiFormat).toString)
 
@@ -180,7 +180,7 @@ class IncorpIdConnectorISpec extends IntegrationSpecBase with AppAndStubs with F
           .audit.writesAudit()
           .audit.writesAuditMerged()
 
-        val validResponse = IncorporatedEntity(testCrn, testCompanyName, None, Some(testChrn), testIncorpDate, "GB", identifiersMatch = true, Some("REGISTERED"), Some(BvPass), Some(testBpSafeId))
+        val validResponse = IncorporatedEntity(testCrn, testCompanyName, None, Some(testChrn), testIncorpDate, "GB", identifiersMatch = true, "REGISTERED", BvPass, Some(testBpSafeId))
         disable(StubIncorpIdJourney)
         stubGet(s"/incorporated-entity-identification/api/journey/$testIncorpId", CREATED, Json.toJson(validResponse)(IncorporatedEntity.apiFormat).toString)
 

--- a/it/controllers/SaveAndRetrieveControllerISpec.scala
+++ b/it/controllers/SaveAndRetrieveControllerISpec.scala
@@ -18,7 +18,7 @@ class SaveAndRetrieveControllerISpec extends ControllerISpec {
   val fullVatSchemeJson = Json.toJson(fullVatScheme)
 
   val s4lKey = "partialVatScheme"
-  val s4lCacheMap = Map(s4lKey -> Json.toJson(fullVatScheme)(VatScheme.s4lFormat))
+  val s4lCacheMap = Map(s4lKey -> Json.toJson(fullVatScheme))
 
   "GET /schemes/save-for-later" when {
     "the VAT scheme is retrieved successfully from the back end" when {

--- a/it/controllers/TradingNameResolverControllerISpec.scala
+++ b/it/controllers/TradingNameResolverControllerISpec.scala
@@ -39,7 +39,7 @@ class TradingNameResolverControllerISpec extends ControllerISpec {
         )
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
         .vatScheme.doesNotHave("trading-details")
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -64,7 +64,7 @@ class TradingNameResolverControllerISpec extends ControllerISpec {
       )
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
         .vatScheme.doesNotHave("trading-details")
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -89,7 +89,7 @@ class TradingNameResolverControllerISpec extends ControllerISpec {
       )
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
         .vatScheme.doesNotHave("trading-details")
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)

--- a/it/controllers/registration/applicant/BusinessIdControllerISpec.scala
+++ b/it/controllers/registration/applicant/BusinessIdControllerISpec.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.registration.applicant
+
+import common.enums.VatRegStatus
+import config.FrontendAppConfig
+import controllers.registration.applicant.{routes => applicantRoutes}
+import itutil.ControllerISpec
+import models.api.{Partnership, Trust, UnincorpAssoc, VatScheme}
+import models.external.{BusinessIdEntity, BusinessVerificationStatus, BvPass}
+import models.{ApplicantDetails, Partner}
+import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.WSResponse
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class BusinessIdControllerISpec extends ControllerISpec {
+
+  val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+  val testUnincorpAssocJourneyId = "1"
+  val testTrustJourneyId = "2"
+  val testJourneyUrl = "/test-journey-url"
+  val createTrustJourneyUrl = "/business-identification/api/trust/journey"
+  val createUnincorpAssocJourneyUrl = "/business-identification/api/unincorporated-association/journey"
+
+  def retrieveDetailsUrl(journeyId: String) = s"/business-identification/api/journey/$journeyId"
+
+  val testPostCode = "ZZ1 1ZZ"
+
+  val testTrustResponse: JsObject = Json.obj(
+    "sautr" -> testSautr,
+    "postcode" -> testPostCode,
+    "chrn" -> testChrn,
+    "businessVerification" -> Json.obj(
+      "verificationStatus" -> Json.toJson[BusinessVerificationStatus](BvPass)
+    ),
+    "registration" -> Json.obj(
+      "registrationStatus" -> testRegistration,
+      "registeredBusinessPartnerId" -> testSafeId
+    ),
+    "identifiersMatch" -> true
+  )
+
+  val testTrust: BusinessIdEntity = BusinessIdEntity(
+    Some(testSautr),
+    Some(testPostCode),
+    Some(testChrn),
+    None,
+    testRegistration,
+    BvPass,
+    Some(testSafeId),
+    identifiersMatch = true
+  )
+
+  val trustApplicantDetails: ApplicantDetails = validFullApplicantDetails.copy(entity = Some(testTrust))
+
+  val testUnincorpAssocResponse: JsObject = Json.obj(
+    "sautr" -> testSautr,
+    "postcode" -> testPostCode,
+    "chrn" -> testChrn,
+    "casc" -> testCasc,
+    "businessVerification" -> Json.obj(
+      "verificationStatus" -> Json.toJson[BusinessVerificationStatus](BvPass)
+    ),
+    "registration" -> Json.obj(
+      "registrationStatus" -> testRegistration,
+      "registeredBusinessPartnerId" -> testSafeId
+    ),
+    "identifiersMatch" -> true
+  )
+
+  val testUnincorpAssoc: BusinessIdEntity = BusinessIdEntity(
+    Some(testSautr),
+    Some(testPostCode),
+    Some(testChrn),
+    Some(testCasc),
+    testRegistration,
+    BvPass,
+    Some(testSafeId),
+    identifiersMatch = true
+  )
+
+  val unincorpAssocApplicantDetails: ApplicantDetails = validFullApplicantDetails.copy(entity = Some(testUnincorpAssoc))
+
+  "GET /start-business-id-journey" when {
+    "STI returns a journey ID" must {
+      "redirect to the journey using the ID provided for Trust" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .vatScheme.contains(fullVatScheme.copy(eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = Trust))))
+
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+        stubPost(createTrustJourneyUrl, CREATED, Json.obj("journeyStartUrl" -> testJourneyUrl).toString())
+
+        val res: Future[WSResponse] = buildClient("/start-business-id-journey").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(testJourneyUrl)
+        }
+      }
+
+      "redirect to the journey using the ID provided for Unincorporated Association" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .vatScheme.contains(fullVatScheme.copy(eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = UnincorpAssoc))))
+
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+        stubPost(createUnincorpAssocJourneyUrl, CREATED, Json.obj("journeyStartUrl" -> testJourneyUrl).toString())
+
+        val res: Future[WSResponse] = buildClient("/start-business-id-journey").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(testJourneyUrl)
+        }
+      }
+    }
+  }
+
+  "GET /business-id-callback" must {
+    "redirect to the lead business entity type page for Trust" when {
+      "S4L model is not full" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .vatScheme.has("applicant-details", Json.toJson(ApplicantDetails()))
+          .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
+          .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails(entity = Some(testTrust)))
+          .vatScheme.contains(
+          VatScheme(
+            id = currentProfile.registrationId,
+            status = VatRegStatus.draft,
+            eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = Trust))
+          )
+        )
+
+        stubGet(retrieveDetailsUrl(testTrustJourneyId), OK, testTrustResponse.toString)
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+
+        val res: Future[WSResponse] = buildClient(s"/register-for-vat/business-id-callback?journeyId=$testTrustJourneyId").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(applicantRoutes.SoleTraderIdentificationController.startJourney().url)
+        }
+      }
+
+      "the model in S4l is full" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .s4lContainer[ApplicantDetails].contains(trustApplicantDetails)
+          .s4lContainer[ApplicantDetails].clearedByKey
+          .vatScheme.isUpdatedWith(trustApplicantDetails)
+          .vatScheme.contains(
+          VatScheme(
+            id = currentProfile.registrationId,
+            status = VatRegStatus.draft,
+            eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = Trust))
+          ))
+
+        stubGet(retrieveDetailsUrl(testTrustJourneyId), OK, testTrustResponse.toString)
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+
+        val res: Future[WSResponse] = buildClient(s"/register-for-vat/business-id-callback?journeyId=$testTrustJourneyId").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(applicantRoutes.SoleTraderIdentificationController.startJourney().url)
+        }
+      }
+    }
+
+    "redirect to the lead business entity type page for Unincorporated Association" when {
+      "S4L model is not full" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .vatScheme.has("applicant-details", Json.toJson(ApplicantDetails()))
+          .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
+          .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails(entity = Some(testUnincorpAssoc)))
+          .vatScheme.contains(
+          VatScheme(
+            id = currentProfile.registrationId,
+            status = VatRegStatus.draft,
+            eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = UnincorpAssoc))
+          )
+        )
+
+        stubGet(retrieveDetailsUrl(testUnincorpAssocJourneyId), OK, testUnincorpAssocResponse.toString)
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+
+        val res: Future[WSResponse] = buildClient(s"/register-for-vat/business-id-callback?journeyId=$testUnincorpAssocJourneyId").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(applicantRoutes.SoleTraderIdentificationController.startJourney().url)
+        }
+      }
+
+      "the model in S4l is full" in new Setup {
+        given()
+          .user.isAuthorised
+          .audit.writesAudit()
+          .audit.writesAuditMerged()
+          .s4lContainer[ApplicantDetails].contains(unincorpAssocApplicantDetails)
+          .s4lContainer[ApplicantDetails].clearedByKey
+          .vatScheme.isUpdatedWith(unincorpAssocApplicantDetails)
+          .vatScheme.contains(
+          VatScheme(
+            id = currentProfile.registrationId,
+            status = VatRegStatus.draft,
+            eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = UnincorpAssoc))
+          ))
+
+        stubGet(retrieveDetailsUrl(testUnincorpAssocJourneyId), OK, testUnincorpAssocResponse.toString)
+        insertCurrentProfileIntoDb(currentProfile, sessionId)
+
+        val res: Future[WSResponse] = buildClient(s"/register-for-vat/business-id-callback?journeyId=$testUnincorpAssocJourneyId").get()
+
+        whenReady(res) { result =>
+          result.status mustBe SEE_OTHER
+          result.headers(LOCATION) must contain(applicantRoutes.SoleTraderIdentificationController.startJourney().url)
+        }
+      }
+    }
+  }
+
+}

--- a/it/controllers/registration/applicant/CaptureEmailAddressControllerISpec.scala
+++ b/it/controllers/registration/applicant/CaptureEmailAddressControllerISpec.scala
@@ -45,6 +45,7 @@ class CaptureEmailAddressControllerISpec extends ControllerISpec {
         .user.isAuthorised
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -60,6 +61,7 @@ class CaptureEmailAddressControllerISpec extends ControllerISpec {
         .audit.writesAudit()
         .s4lContainer[ApplicantDetails].contains(s4lData)
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -84,6 +86,7 @@ class CaptureEmailAddressControllerISpec extends ControllerISpec {
           )
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -106,6 +109,7 @@ class CaptureEmailAddressControllerISpec extends ControllerISpec {
           )
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -124,10 +128,11 @@ class CaptureEmailAddressControllerISpec extends ControllerISpec {
         given()
           .user.isAuthorised
           .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails.copy(emailAddress = None))
-          .vatScheme.patched("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+          .vatScheme.patched("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
           .s4lContainer[ApplicantDetails].clearedByKey
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/CaptureEmailPasscodeControllerISpec.scala
+++ b/it/controllers/registration/applicant/CaptureEmailPasscodeControllerISpec.scala
@@ -39,6 +39,7 @@ class CaptureEmailPasscodeControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].contains(s4lContents)
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -59,6 +60,7 @@ class CaptureEmailPasscodeControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].isUpdatedWith(s4lContents.copy(emailVerified = Some(EmailVerified(true))))
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -78,6 +80,7 @@ class CaptureEmailPasscodeControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].contains(s4lContents)
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -96,6 +99,7 @@ class CaptureEmailPasscodeControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].contains(s4lContents)
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -113,6 +117,7 @@ class CaptureEmailPasscodeControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].contains(s4lContents)
           .audit.writesAudit()
           .audit.writesAuditMerged()
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/CaptureRoleInTheBusinessControllerISpec.scala
+++ b/it/controllers/registration/applicant/CaptureRoleInTheBusinessControllerISpec.scala
@@ -31,6 +31,7 @@ class CaptureRoleInTheBusinessControllerISpec extends ControllerISpec {
         .audit.writesAudit()
         .s4lContainer[ApplicantDetails].contains(s4lData)
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -56,6 +57,7 @@ class CaptureRoleInTheBusinessControllerISpec extends ControllerISpec {
           .audit.writesAuditMerged()
           .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
           .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails().copy())
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -75,8 +77,9 @@ class CaptureRoleInTheBusinessControllerISpec extends ControllerISpec {
           .audit.writesAudit()
           .audit.writesAuditMerged()
           .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
-          .vatScheme.patched(keyblock, Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+          .vatScheme.patched(keyblock, Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
           .s4lContainer[ApplicantDetails].clearedByKey
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/CaptureTelephoneNumberControllerISpec.scala
+++ b/it/controllers/registration/applicant/CaptureTelephoneNumberControllerISpec.scala
@@ -48,6 +48,7 @@ class CaptureTelephoneNumberControllerISpec extends ControllerISpec {
         .user.isAuthorised
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -58,12 +59,12 @@ class CaptureTelephoneNumberControllerISpec extends ControllerISpec {
     }
 
     "returns an OK with prepopulated data" in new Setup {
-
       given()
         .user.isAuthorised
         .audit.writesAudit()
         .s4lContainer[ApplicantDetails].contains(s4lData)
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -88,6 +89,7 @@ class CaptureTelephoneNumberControllerISpec extends ControllerISpec {
           .audit.writesAuditMerged()
           .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
           .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails().copy(telephoneNumber = Some(TelephoneNumber(testPhoneNumber))))
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -106,8 +108,9 @@ class CaptureTelephoneNumberControllerISpec extends ControllerISpec {
           .audit.writesAudit()
           .audit.writesAuditMerged()
           .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
-          .vatScheme.patched(keyblock, Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+          .vatScheme.patched(keyblock, Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
           .s4lContainer[ApplicantDetails].clearedByKey
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/FormerNameControllerISpec.scala
+++ b/it/controllers/registration/applicant/FormerNameControllerISpec.scala
@@ -51,10 +51,10 @@ class FormerNameControllerISpec extends ControllerISpec {
 
   s"GET $url" must {
     "returns an OK" in new Setup {
-
       given()
         .user.isAuthorised
         .audit.writesAudit()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -65,11 +65,11 @@ class FormerNameControllerISpec extends ControllerISpec {
     }
 
     "returns an OK with prepopulated data" in new Setup {
-
       given()
         .user.isAuthorised
         .audit.writesAudit()
         .s4lContainer[ApplicantDetails].contains(s4lData)
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -114,6 +114,7 @@ class FormerNameControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].clearedByKey
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -140,6 +141,7 @@ class FormerNameControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].isUpdatedWith(s4lData)
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -163,6 +165,7 @@ class FormerNameControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].isUpdatedWith(updatedS4LData)
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/HomeAddressControllerISpec.scala
+++ b/it/controllers/registration/applicant/HomeAddressControllerISpec.scala
@@ -50,6 +50,7 @@ class HomeAddressControllerISpec extends ControllerISpec {
         .user.isAuthorised
         .s4lContainer[ApplicantDetails].contains(s4lData)
         .alfeJourney.initialisedSuccessfully()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -114,6 +115,7 @@ class HomeAddressControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].clearedByKey
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/IncorpIdControllerISpec.scala
+++ b/it/controllers/registration/applicant/IncorpIdControllerISpec.scala
@@ -132,6 +132,7 @@ class IncorpIdControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
           .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails(entity = Some(testIncorpDetails)))
           .vatScheme.has("applicant-details", Json.toJson(ApplicantDetails()))
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         stubGet("/incorporated-entity-identification/api/journey/1", OK, incorpDetailsJson.toString)
 
@@ -156,6 +157,7 @@ class IncorpIdControllerISpec extends ControllerISpec {
           .s4lContainer[ApplicantDetails].contains(ApplicantDetails())
           .s4lContainer[ApplicantDetails].isUpdatedWith(ApplicantDetails(entity = Some(testIncorpDetails)))
           .vatScheme.has("applicant-details", Json.toJson(ApplicantDetails()))
+          .vatScheme.contains(emptyUkCompanyVatScheme)
 
         stubGet("/incorporated-entity-identification/api/journey/1", OK, incorpDetailsJson.toString)
 

--- a/it/controllers/registration/applicant/PersonalDetailsValidationControllerISpec.scala
+++ b/it/controllers/registration/applicant/PersonalDetailsValidationControllerISpec.scala
@@ -32,6 +32,7 @@ class PersonalDetailsValidationControllerISpec extends ControllerISpec {
       given()
         .user.isAuthorised
         .audit.writesAudit()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -48,7 +49,7 @@ class PersonalDetailsValidationControllerISpec extends ControllerISpec {
       disable(StubPersonalDetailsValidation)
 
       val testValidationId: String = "testValidationId"
-      val applicantJson = Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiWrites)
+      val applicantJson = Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes)
 
       given()
         .user.isAuthorised
@@ -57,6 +58,7 @@ class PersonalDetailsValidationControllerISpec extends ControllerISpec {
         .vatScheme.patched("applicant-details", applicantJson)
         .s4lContainer[ApplicantDetails].isUpdatedWith(validFullApplicantDetails)
         .s4lContainer[ApplicantDetails].cleared
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/PreviousAddressControllerISpec.scala
+++ b/it/controllers/registration/applicant/PreviousAddressControllerISpec.scala
@@ -83,6 +83,7 @@ class PreviousAddressControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].clearedByKey
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -164,6 +165,7 @@ class PreviousAddressControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].clearedByKey
         .audit.writesAudit()
         .audit.writesAuditMerged()
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/applicant/SoleTraderIdentificationControllerISpec.scala
+++ b/it/controllers/registration/applicant/SoleTraderIdentificationControllerISpec.scala
@@ -120,7 +120,7 @@ class SoleTraderIdentificationControllerISpec extends ControllerISpec {
         .audit.writesAuditMerged()
         .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
         .s4lContainer[ApplicantDetails].clearedByKey
-        .vatScheme.isUpdatedWith(validFullApplicantDetails)
+        .vatScheme.isUpdatedWith(validFullApplicantDetails)(ApplicantDetails.writes)
         .vatScheme.contains(
         VatScheme(id = currentProfile.registrationId,
           status = VatRegStatus.draft,
@@ -145,7 +145,7 @@ class SoleTraderIdentificationControllerISpec extends ControllerISpec {
         .audit.writesAuditMerged()
         .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
         .s4lContainer[ApplicantDetails].clearedByKey
-        .vatScheme.isUpdatedWith(validFullApplicantDetails)
+        .vatScheme.isUpdatedWith(validFullApplicantDetails)(ApplicantDetails.writes)
         .vatScheme.contains(
         VatScheme(id = currentProfile.registrationId,
           status = VatRegStatus.draft,
@@ -220,7 +220,7 @@ class SoleTraderIdentificationControllerISpec extends ControllerISpec {
         .audit.writesAuditMerged()
         .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
         .s4lContainer[ApplicantDetails].clearedByKey
-        .vatScheme.isUpdatedWith(validFullApplicantDetails)
+        .vatScheme.isUpdatedWith(validFullApplicantDetails)(ApplicantDetails.writes)
         .vatScheme.isUpdatedWithPartner(PartnerEntity(testSoleTrader, Individual, isLeadPartner = true))
         .vatScheme.contains(
         VatScheme(id = currentProfile.registrationId,

--- a/it/controllers/registration/business/TradingNameControllerISpec.scala
+++ b/it/controllers/registration/business/TradingNameControllerISpec.scala
@@ -33,8 +33,9 @@ class TradingNameControllerISpec extends ControllerISpec {
         .s4lContainer[ApplicantDetails].isUpdatedWith(validFullApplicantDetails)
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat))
+        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
         .vatScheme.doesNotHave("trading-details")
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -53,9 +54,10 @@ class TradingNameControllerISpec extends ControllerISpec {
         .vatScheme.doesNotHave("trading-details")
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails))
+        .vatScheme.has("applicant-details", Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes))
         .vatScheme.isUpdatedWith(tradingDetails.copy(tradingNameView = Some(TradingNameView(true, Some("Test Trading Name")))))
         .s4lContainer[TradingDetails].clearedByKey
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/registration/returns/ReturnsControllerISpec.scala
+++ b/it/controllers/registration/returns/ReturnsControllerISpec.scala
@@ -21,6 +21,7 @@ class ReturnsControllerISpec extends ControllerISpec {
         .s4lContainer[Returns].contains(Returns(None, None, None, None, Some(testApplicantIncorpDate)))
         .s4lContainer[ApplicantDetails].contains(validFullApplicantDetails)
         .vatScheme.has("threshold-data", Json.toJson(Threshold(mandatoryRegistration = false)))
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       val res = buildClient("/vat-start-date").get()
 
@@ -46,7 +47,7 @@ class ReturnsControllerISpec extends ControllerISpec {
   "POST /vat-start-date" must {
     "Redirect to the next page when all data is valid" in {
       val today = LocalDate.now().plusDays(1)
-      val applicantJson = Json.toJson(validFullApplicantDetails)(ApplicantDetails.apiFormat)
+      val applicantJson = Json.toJson(validFullApplicantDetails)(ApplicantDetails.writes)
 
       given()
         .user.isAuthorised
@@ -55,6 +56,7 @@ class ReturnsControllerISpec extends ControllerISpec {
         .vatScheme.has("threshold-data", Json.toJson(Threshold(mandatoryRegistration = false)))
         .vatScheme.has("applicant-details", applicantJson)
         .vatScheme.patched("applicant-details", applicantJson)
+        .vatScheme.contains(emptyUkCompanyVatScheme)
 
       val res = buildClient("/vat-start-date").post(Json.obj(
         "value" -> DateSelection.specific_date,

--- a/it/fixtures/ApplicantDetailsFixture.scala
+++ b/it/fixtures/ApplicantDetailsFixture.scala
@@ -38,7 +38,7 @@ trait ApplicantDetailsFixture {
   val testApplicantIncorpDate = LocalDate.of(2020, 2, 3)
   val testBpSafeId = "testBpId"
 
-  val testApplicantIncorpDetails = IncorporatedEntity(testApplicantCrn, testApplicantCompanyName, Some(testApplicantCtUtr), None, testApplicantIncorpDate, "GB", identifiersMatch = true, Some("REGISTERED"), Some(BvPass), Some(testBpSafeId))
+  val testApplicantIncorpDetails = IncorporatedEntity(testApplicantCrn, testApplicantCompanyName, Some(testApplicantCtUtr), None, testApplicantIncorpDate, "GB", identifiersMatch = true, "REGISTERED", BvPass, Some(testBpSafeId))
 
   val validFullApplicantDetails = ApplicantDetails(
     transactor = Some(testTransactorDetails),

--- a/it/fixtures/ITRegistrationFixtures.scala
+++ b/it/fixtures/ITRegistrationFixtures.scala
@@ -104,6 +104,11 @@ trait ITRegistrationFixtures extends ApplicantDetailsFixture {
     """.stripMargin
   )
 
+  val emptyUkCompanyVatScheme: VatScheme = VatScheme(
+    testRegId,
+    status = VatRegStatus.draft,
+    eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = UkCompany))
+  )
 
   val vatReg = VatScheme(
     id = "1",
@@ -177,11 +182,12 @@ trait ITRegistrationFixtures extends ApplicantDetailsFixture {
 
   val testCrn = "testCrn"
   val testChrn = "testChrn"
+  val testCasc = "testCasc"
   val testCompanyName = "testCompanyName"
   val testCtUtr = "testCtUtr"
   val testIncorpDate = LocalDate.of(2020, 2, 3)
 
-  val testIncorpDetails = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, "GB", identifiersMatch = true, Some("REGISTERED"), Some(BvPass), Some(testBpSafeId))
+  val testIncorpDetails = IncorporatedEntity(testCrn, testCompanyName, Some(testCtUtr), None, testIncorpDate, "GB", identifiersMatch = true, "REGISTERED", BvPass, Some(testBpSafeId))
 
   val testSautr = "1234567890"
   val testRegistration = "REGISTERED"

--- a/it/support/AppAndStubs.scala
+++ b/it/support/AppAndStubs.scala
@@ -118,6 +118,7 @@ trait AppAndStubs extends StubUtils with GuiceOneServerPerSuite with Integration
       "iv.identity-verification-frontend",
       "sole-trader-identification-frontend",
       "partnership-identification-frontend",
+      "business-identification-frontend",
       "upscan-initiate"
     )) ++ additionalConfig)
     .configure("application.router" -> "testOnlyDoNotUseInAppConf.Routes")

--- a/it/support/StubUtils.scala
+++ b/it/support/StubUtils.scala
@@ -173,7 +173,7 @@ trait StubUtils {
     }
 
 
-    def stubS4LGet[C, T](t: T)(implicit key: S4LKey[C], fmt: Format[T]): MappingBuilder = {
+    def stubS4LGet[C, T](t: T)(implicit key: S4LKey[C], fmt: Writes[T]): MappingBuilder = {
       val s4lData = Json.toJson(t)
       val encData = encryptionFormat.writes(Protected(s4lData)).as[JsString]
 
@@ -252,12 +252,12 @@ trait StubUtils {
   @deprecated("please change the types on this once all refactoring has been completed, both should be same type instead of C & T")
   class ViewModelStub[C]()(implicit builder: PreconditionBuilder, s4LKey: S4LKey[C]) {
 
-    def contains[T](t: T)(implicit fmt: Format[T]): PreconditionBuilder = {
+    def contains[T](t: T)(implicit fmt: Writes[T]): PreconditionBuilder = {
       stubFor(S4LStub.stubS4LGet[C, T](t))
       builder
     }
 
-    def isUpdatedWith(t: C)(implicit key: S4LKey[C], fmt: Format[C]): PreconditionBuilder = {
+    def isUpdatedWith(t: C)(implicit key: S4LKey[C], fmt: Writes[C]): PreconditionBuilder = {
       stubFor(S4LStub.stubS4LPut(key.key, fmt.writes(t).toString()))
       builder
     }
@@ -490,7 +490,7 @@ trait StubUtils {
       builder
     }
 
-    def isUpdatedWith[T](t: T)(implicit tFmt: Format[T]) = {
+    def isUpdatedWith[T](t: T)(implicit tFmt: Writes[T]) = {
       stubFor(
         patch(urlPathMatching(s"/vatreg/1/.*"))
           .willReturn(aResponse().withStatus(202).withBody(tFmt.writes(t).toString())))

--- a/test/connectors/VatRegistrationConnectorSpec.scala
+++ b/test/connectors/VatRegistrationConnectorSpec.scala
@@ -331,32 +331,32 @@ class VatRegistrationConnectorSpec extends VatRegSpec with VatRegistrationFixtur
   "Calling getApplicantDetails(testRegId)" should {
     "return ApplicantDetails" in new Setup {
       mockHttpGET[Option[ApplicantDetails]]("tst-url", Some(completeApplicantDetails))
-      connector.getApplicantDetails(testRegId) returns Some(completeApplicantDetails)
+      connector.getApplicantDetails(testRegId, UkCompany) returns Some(completeApplicantDetails)
     }
 
     "return empty ApplicantDetails" in new Setup {
       mockHttpGET[Option[ApplicantDetails]]("tst-url", None)
-      connector.getApplicantDetails(testRegId) returns None
+      connector.getApplicantDetails(testRegId, UkCompany) returns None
     }
 
     "throw a NotFoundException if the registration does not exist" in new Setup {
       mockHttpFailedGET[HttpResponse]("tst-url", notFound)
-      connector.getApplicantDetails(testRegId) failedWith notFound
+      connector.getApplicantDetails(testRegId, UkCompany) failedWith notFound
     }
 
     "throw an Upstream4xxResponse with Forbidden status" in new Setup {
       mockHttpFailedGET[HttpResponse]("tst-url", forbidden)
-      connector.getApplicantDetails(testRegId) failedWith forbidden
+      connector.getApplicantDetails(testRegId, UkCompany) failedWith forbidden
     }
 
     "throw an Upstream5xxResponse with Internal Server Error status" in new Setup {
       mockHttpFailedGET[HttpResponse]("tst-url", internalServerError)
-      connector.getApplicantDetails(testRegId) failedWith internalServerError
+      connector.getApplicantDetails(testRegId, UkCompany) failedWith internalServerError
     }
 
     "throw an Exception if the call failed" in new Setup {
       mockHttpFailedGET[HttpResponse]("tst-url", exception)
-      connector.getApplicantDetails(testRegId) failedWith exception
+      connector.getApplicantDetails(testRegId, UkCompany) failedWith exception
     }
   }
 

--- a/test/controllers/TradingNameResolverControllerSpec.scala
+++ b/test/controllers/TradingNameResolverControllerSpec.scala
@@ -44,7 +44,7 @@ class TradingNameResolverControllerSpec extends ControllerSpec
   }
 
   "resolve" must {
-    List(Individual, Partnership, Trust).foreach { partyType =>
+    List(Individual, Partnership, Trust, UnincorpAssoc).foreach { partyType =>
       s"redirects to ${controllers.registration.business.routes.MandatoryTradingNameController.show().url} for partyType ${partyType.toString}" in new Setup {
         mockPartyType(Future.successful(partyType))
         val res = Controller.resolve()(FakeRequest())

--- a/test/controllers/registration/applicant/SoleTraderIdentificationControllerSpec.scala
+++ b/test/controllers/registration/applicant/SoleTraderIdentificationControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.registration.applicant
 
 import fixtures.VatRegistrationFixture
-import models.api.{CharitableOrg, Individual, RegSociety, Trust, UkCompany}
+import models.api._
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import services.mocks.{MockApplicantDetailsService, MockPartnersService, MockSoleTraderIdService, MockVatRegistrationService}
@@ -87,7 +87,7 @@ class SoleTraderIdentificationControllerSpec extends ControllerSpec
       redirectLocation(res) must contain(controllers.registration.applicant.routes.FormerNameController.show().url)
     }
 
-    List(UkCompany, RegSociety, CharitableOrg, Trust).foreach { partyType =>
+    List(UkCompany, RegSociety, CharitableOrg, Trust, UnincorpAssoc).foreach { partyType =>
       s"redirect to the capture role in the business page if the user is ${partyType.toString}" in new Setup {
         mockGetVatScheme(Future.successful(validVatScheme))
         mockRetrieveSoleTraderDetails(testJourneyId)(Future.successful((testTransactorDetails, testSoleTrader)))

--- a/test/fixtures/ApplicantDetailsFixtures.scala
+++ b/test/fixtures/ApplicantDetailsFixtures.scala
@@ -35,6 +35,7 @@ trait ApplicantDetailsFixtures {
 
   val testCrn = "testCrn"
   val testChrn = "testChrn"
+  val testCasc = "testCasc"
   val testCompanyName = "testCompanyName"
   val testCtUtr = "testCtUtr"
   val testIncorpDate = LocalDate.of(2020, 2, 3)
@@ -64,8 +65,8 @@ trait ApplicantDetailsFixtures {
     testIncorpDate,
     "GB",
     identifiersMatch = true,
-    Some("REGISTERED"),
-    Some(BvPass),
+    "REGISTERED",
+    BvPass,
     Some(testBpSafeId)
   )
 
@@ -116,17 +117,28 @@ trait ApplicantDetailsFixtures {
   val testGeneralPartnership: PartnershipIdEntity = PartnershipIdEntity(
     sautr = Some(testSautr),
     postCode = Some(testPostcode),
-    chrn = None,
     registration = testRegistration,
     businessVerification = BvPass,
     bpSafeId = Some(testSafeId),
     identifiersMatch = true
   )
 
-  val testTrust: PartnershipIdEntity = PartnershipIdEntity(
+  val testTrust: BusinessIdEntity = BusinessIdEntity(
     sautr = Some(testSautr),
     postCode = None,
     chrn = Some(testChrn),
+    casc = None,
+    registration = testRegistration,
+    businessVerification = BvPass,
+    bpSafeId = Some(testSafeId),
+    identifiersMatch = true
+  )
+
+  val testUnincorpAssoc: BusinessIdEntity = BusinessIdEntity(
+    sautr = Some(testSautr),
+    postCode = None,
+    chrn = Some(testChrn),
+    casc = Some(testCasc),
     registration = testRegistration,
     businessVerification = BvPass,
     bpSafeId = Some(testSafeId),
@@ -140,7 +152,10 @@ trait ApplicantDetailsFixtures {
     chrn = None,
     dateOfIncorporation = testIncorpDate,
     countryOfIncorporation = testIncorpCountry,
-    identifiersMatch = true
+    identifiersMatch = true,
+    registration = testRegistration,
+    businessVerification = BvPass,
+    bpSafeId = Some(testSafeId)
   )
 
   val testCharitableOrganisation: IncorporatedEntity = IncorporatedEntity(
@@ -150,6 +165,9 @@ trait ApplicantDetailsFixtures {
     chrn = Some(testChrn),
     dateOfIncorporation = testIncorpDate,
     countryOfIncorporation = testIncorpCountry,
-    identifiersMatch = true
+    identifiersMatch = true,
+    registration = testRegistration,
+    businessVerification = BvPass,
+    bpSafeId = Some(testSafeId)
   )
 }

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -128,6 +128,7 @@ trait VatRegistrationFixture extends FlatRateFixtures with TradingDetailsFixture
   val s4lVatSicAndComplianceWithoutLabour = SicAndCompliance(
     description = Some(BusinessActivityDescription(testBusinessActivityDescription)),
     mainBusinessActivity = Some(MainBusinessActivityView(sicCode.code, Some(sicCode))),
+    businessActivities = Some(BusinessActivities(List(sicCode))),
     supplyWorkers = None,
     workers = None,
     intermediarySupply = None)

--- a/test/models/external/incorporatedentityid/IncorporatedEntitySpec.scala
+++ b/test/models/external/incorporatedentityid/IncorporatedEntitySpec.scala
@@ -24,7 +24,7 @@ class IncorporatedEntitySpec extends VatRegSpec {
 
   "LimitedCompany" should {
     "parse successfully without optional data" in {
-      val incorpDetails = testLimitedCompany.copy(businessVerification = None, bpSafeId = None)
+      val incorpDetails = testLimitedCompany.copy(bpSafeId = None)
       val json = Json.toJson(incorpDetails)
       json.as[IncorporatedEntity] mustBe incorpDetails
     }
@@ -38,7 +38,7 @@ class IncorporatedEntitySpec extends VatRegSpec {
 
   "LimitedCompany apiFormat" should {
     "parse successfully without optional data" in {
-      val incorpDetails = testLimitedCompany.copy(businessVerification = None, bpSafeId = None)
+      val incorpDetails = testLimitedCompany.copy(bpSafeId = None)
       val json = Json.toJson(incorpDetails)(IncorporatedEntity.apiFormat)
       json.as[IncorporatedEntity](IncorporatedEntity.apiFormat) mustBe incorpDetails
     }

--- a/test/models/view/ApplicantDetailsSpec.scala
+++ b/test/models/view/ApplicantDetailsSpec.scala
@@ -18,7 +18,7 @@ package models.view
 
 import java.time.LocalDate
 import models.{ApplicantDetails, TelephoneNumber}
-import models.api.Address
+import models.api.{Address, UkCompany}
 import models.external.{EmailAddress, EmailVerified, Name}
 import play.api.libs.json.{JsSuccess, Json}
 import testHelpers.VatRegSpec
@@ -47,7 +47,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
         previousAddress = Some(PreviousAddressView(true, None))
       )
 
-      ApplicantDetails.apiReads.reads(json) mustBe JsSuccess(applicantDetails)
+      ApplicantDetails.reads(UkCompany).reads(json) mustBe JsSuccess(applicantDetails)
     }
 
     "return a correct partial ApplicantDetails view model with partial name" in {
@@ -68,7 +68,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
         previousAddress = Some(PreviousAddressView(true, None))
       )
 
-      ApplicantDetails.apiReads.reads(json) mustBe JsSuccess(applicantDetails)
+      ApplicantDetails.reads(UkCompany).reads(json) mustBe JsSuccess(applicantDetails)
     }
 
     "return a correct full ApplicantDetails view model with max data" in {
@@ -137,7 +137,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
         previousAddress = Some(PreviousAddressView(yesNo = false, Some(previousAddress)))
       )
 
-      ApplicantDetails.apiReads.reads(json) mustBe JsSuccess(applicantDetails)
+      ApplicantDetails.reads(UkCompany).reads(json) mustBe JsSuccess(applicantDetails)
     }
 
     "return a correct full ApplicantDetails view model with min data" in {
@@ -176,7 +176,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
         previousAddress = Some(PreviousAddressView(yesNo = true, None))
       )
 
-      ApplicantDetails.apiReads.reads(json) mustBe JsSuccess(applicantDetails)
+      ApplicantDetails.reads(UkCompany).reads(json) mustBe JsSuccess(applicantDetails)
     }
   }
 
@@ -185,7 +185,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
       val data = ApplicantDetails()
       val validJson = Json.obj()
 
-      Json.toJson(data)(ApplicantDetails.apiWrites) mustBe validJson
+      Json.toJson(data)(ApplicantDetails.writes) mustBe validJson
     }
 
     "return a correct full JsValue with maximum data" in {
@@ -250,7 +250,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
            |  }
            |}""".stripMargin)
 
-      Json.toJson(data)(ApplicantDetails.apiWrites) mustBe validJson
+      Json.toJson(data)(ApplicantDetails.writes) mustBe validJson
     }
 
     "return a correct full JsValue with minimum data" in {
@@ -279,7 +279,7 @@ class ApplicantDetailsSpec extends VatRegSpec {
            |  }
            |}""".stripMargin)
 
-      Json.toJson(data)(ApplicantDetails.apiWrites) mustBe validJson
+      Json.toJson(data)(ApplicantDetails.writes) mustBe validJson
     }
   }
 

--- a/test/services/S4LServiceSpec.scala
+++ b/test/services/S4LServiceSpec.scala
@@ -17,7 +17,9 @@
 package services
 
 import fixtures.VatRegistrationFixture
+import models.api.UkCompany
 import models.{ApplicantDetails, _}
+import play.api.libs.json.{Reads, Writes}
 import testHelpers.VatRegSpec
 import uk.gov.hmrc.http.cache.client.CacheMap
 
@@ -32,12 +34,14 @@ class S4LServiceSpec extends VatRegSpec {
       mockKeystoreFetchAndGet[String]("RegistrationId", Some(testRegId))
       private val cacheMap = CacheMap("s-date", Map.empty)
       mockS4LSaveForm[ApplicantDetails](cacheMap)
+      implicit val writes: Writes[ApplicantDetails] = ApplicantDetails.s4LWrites
       service.save(emptyApplicantDetails) returns cacheMap
     }
 
     "fetch a form with the correct key" in new Setup {
       mockKeystoreFetchAndGet[String]("RegistrationId", Some(testRegId))
       mockS4LFetchAndGet(S4LKey[ApplicantDetails].key, Some(emptyApplicantDetails))
+      implicit val reads: Reads[ApplicantDetails]= ApplicantDetails.s4LReads(UkCompany)
       service.fetchAndGet[ApplicantDetails] returns Some(emptyApplicantDetails)
     }
 


### PR DESCRIPTION
The service currently doesn't exist and I assumed it'd be called business identification frontend. The stub is also set up so journey is testable. Trust has been moved from partnership id to the new one as well.

Business entity models are now dependent on partytype to help enforce rules on the models, currently one model per ID service. The applicant details reads now require knowledge of the partytype which is fine as it should always be there after eligibility.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
