### PR TITLE
SAR-8439/SAR-8750 store validation status in BankAccountDetails

### DIFF
--- a/app/forms/BankAccountDetailsForms.scala
+++ b/app/forms/BankAccountDetailsForms.scala
@@ -18,6 +18,7 @@ package forms
 
 import forms.FormValidation._
 import models.BankAccountDetails
+import models.api.{BankAccountDetailsStatus, IndeterminateStatus}
 import play.api.data.Forms._
 import play.api.data.{Form, Mapping}
 import uk.gov.hmrc.play.mappers.StopOnFirstFail
@@ -68,7 +69,13 @@ object EnterBankAccountDetailsForm {
         mandatory(sortCodeEmptyKey),
         matchesRegex(sortCodeRegex, sortCodeInvalidKey)
       ))
-    )(BankAccountDetails.apply)(BankAccountDetails.unapply)
+    )
+    ((accountName, accountNumber, sortCode) => BankAccountDetails.apply(accountName, accountNumber, sortCode, None))
+    (bankAccountDetails =>
+      BankAccountDetails.unapply(bankAccountDetails).map {
+        case (accountName, accountNumber, sortCode, _) => (accountName, accountNumber, sortCode)
+      }
+    )
   )
 
   val formWithInvalidAccountReputation: Form[BankAccountDetails] =

--- a/app/models/api/BankAccountDetailsStatus.scala
+++ b/app/models/api/BankAccountDetailsStatus.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.api
+
+import play.api.libs.json.{Format, JsString}
+
+sealed trait BankAccountDetailsStatus
+case object ValidStatus extends BankAccountDetailsStatus
+case object InvalidStatus extends BankAccountDetailsStatus
+case object IndeterminateStatus extends BankAccountDetailsStatus
+
+object BankAccountDetailsStatus {
+
+  val map: Map[BankAccountDetailsStatus, String] = Map(
+    ValidStatus -> "yes",
+    InvalidStatus -> "no",
+    IndeterminateStatus -> "indeterminate"
+  )
+  val inverseMap: Map[String, BankAccountDetailsStatus] = map.map(_.swap)
+
+  def fromString(value: String): BankAccountDetailsStatus = inverseMap(value)
+  def toJsString(value: BankAccountDetailsStatus): JsString = JsString(map(value))
+
+  implicit val format = Format[BankAccountDetailsStatus](_.validate[String] map fromString, toJsString)
+}

--- a/test/services/BankAccountReputationServiceSpec.scala
+++ b/test/services/BankAccountReputationServiceSpec.scala
@@ -18,6 +18,7 @@ package services
 
 import featureswitch.core.config.{FeatureSwitching, StubBars}
 import models.BankAccountDetails
+import models.api.{IndeterminateStatus, InvalidStatus, ValidStatus}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -41,7 +42,7 @@ class BankAccountReputationServiceSpec extends VatRegSpec with S4LMockSugar with
   "Calling validateBankDetails" should {
     val bankDetails = BankAccountDetails("testName", "12-34-56", "12345678")
 
-    "return true when the json returns a true" in new Setup {
+    "return ValidStatus when the json returns a true" in new Setup {
       val testUserId = "testUserId"
 
       when(mockBankAccountReputationConnector.validateBankDetails(any())(any()))
@@ -54,13 +55,13 @@ class BankAccountReputationServiceSpec extends VatRegSpec with S4LMockSugar with
         "response" -> validBankCheckJsonResponse
       )
 
-      service.validateBankDetails(bankDetails) returns true
+      service.validateBankDetails(bankDetails) returns ValidStatus
 
       verify(mockAuditConnector).sendExplicitAudit(ArgumentMatchers.eq("BarsValidateCheck"), ArgumentMatchers.eq(testAuditRequest)
       )(ArgumentMatchers.any[HeaderCarrier], ArgumentMatchers.any[ExecutionContext])
     }
 
-    "return false when the json returns a false" in new Setup {
+    "return InvalidStatus when the json returns a false" in new Setup {
       val testUserId = "testUserId"
 
       when(mockBankAccountReputationConnector.validateBankDetails(any())(any()))
@@ -73,13 +74,13 @@ class BankAccountReputationServiceSpec extends VatRegSpec with S4LMockSugar with
         "response" -> invalidBankCheckJsonResponse
       )
 
-      service.validateBankDetails(bankDetails) returns false
+      service.validateBankDetails(bankDetails) returns InvalidStatus
 
       verify(mockAuditConnector).sendExplicitAudit(ArgumentMatchers.eq("BarsValidateCheck"), ArgumentMatchers.eq(testAuditRequest)
       )(ArgumentMatchers.any[HeaderCarrier], ArgumentMatchers.any[ExecutionContext])
     }
 
-    "return false when the json returns indeterminate" in new Setup {
+    "return IndeterminateStatus when the json returns indeterminate" in new Setup {
       val testUserId = "testUserId"
 
       when(mockBankAccountReputationConnector.validateBankDetails(any())(any()))
@@ -92,7 +93,7 @@ class BankAccountReputationServiceSpec extends VatRegSpec with S4LMockSugar with
         "response" -> indeterminateBankCheckJsonResponse
       )
 
-      service.validateBankDetails(bankDetails) returns false
+      service.validateBankDetails(bankDetails) returns IndeterminateStatus
 
       verify(mockAuditConnector).sendExplicitAudit(ArgumentMatchers.eq("BarsValidateCheck"), ArgumentMatchers.eq(testAuditRequest)
       )(ArgumentMatchers.any[HeaderCarrier], ArgumentMatchers.any[ExecutionContext])
@@ -104,7 +105,7 @@ class BankAccountReputationServiceSpec extends VatRegSpec with S4LMockSugar with
         .thenReturn(Future.successful(Json.obj("accountNumberWithSortCodeIsValid"-> "false")))
       mockAuthenticatedInternalId(Some(testUserId))
 
-      intercept[InternalServerException] {
+      intercept[NoSuchElementException] {
         await(service.validateBankDetails(bankDetails))
       }
     }


### PR DESCRIPTION
SAR-8439/SAR-8750
Allow users who are indeterminate to proceed and update BankAccountDetails model to store the state returned from BARS

**New feature**

## Checklist

* [√] I've included appropriate tests with any code I've added
* [√] I've executed the acceptance test pack locally to ensure there are no regressions
* [√] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
