### PR TITLE
SAR-9234 restrict file types upload in Upscan

### DIFF
--- a/app/connectors/UpscanConnector.scala
+++ b/app/connectors/UpscanConnector.scala
@@ -20,6 +20,7 @@ import config.FrontendAppConfig
 import models.external.upscan.{UpscanDetails, UpscanResponse}
 import play.api.http.Status._
 import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, InternalServerException}
 
 import javax.inject.{Inject, Singleton}
@@ -28,14 +29,14 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class UpscanConnector @Inject()(httpClient: HttpClient, appConfig: FrontendAppConfig)(implicit executionContext: ExecutionContext) {
 
-  def upscanInitiate()(implicit hc: HeaderCarrier): Future[UpscanResponse] = {
+  def upscanInitiate()(implicit hc: HeaderCarrier, request: Request[AnyContent]): Future[UpscanResponse] = {
     lazy val url = appConfig.setupUpscanJourneyUrl
     lazy val body = Json.obj(
       "callbackUrl" -> appConfig.storeUpscanCallbackUrl,
-      "successRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.url,
+      "successRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.absoluteURL(),
+      "errorRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.absoluteURL(),
       "minimumFileSize" -> 0,
-      "maximumFileSize" -> 10485760,
-      "expectedContentType" -> "image/jpeg"
+      "maximumFileSize" -> 10485760
     )
 
     httpClient.POST[JsValue, HttpResponse](url, body).map {

--- a/app/services/UpscanService.scala
+++ b/app/services/UpscanService.scala
@@ -18,6 +18,7 @@ package services
 
 import connectors.UpscanConnector
 import models.external.upscan.{UpscanDetails, UpscanResponse}
+import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
@@ -26,7 +27,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class UpscanService @Inject()(upscanConnector: UpscanConnector)(implicit executionContext: ExecutionContext) {
 
-  def initiateUpscan(regId: String)(implicit hc: HeaderCarrier): Future[UpscanResponse] = {
+  def initiateUpscan(regId: String)(implicit hc: HeaderCarrier, request: Request[AnyContent]): Future[UpscanResponse] = {
     upscanConnector.upscanInitiate().flatMap { response =>
       upscanConnector.storeUpscanReference(regId, response.reference).map(_ => response)
     }

--- a/app/views/fileUpload/file_upload.scala.html
+++ b/app/views/fileUpload/file_upload.scala.html
@@ -45,7 +45,7 @@
             label = Label(
                 content = Text("Upload a file")
             ),
-            attributes = Map("accept" -> ".jpeg,.jpg")
+            attributes = Map("accept" -> ".pdf,.doc,.docx,.xls,.xlsx,.bmp,.gif,.png,.jpeg,.jpg,.txt")
         ))
 
         @govukButton(Button(

--- a/it/connectors/UpscanConnectorISpec.scala
+++ b/it/connectors/UpscanConnectorISpec.scala
@@ -22,6 +22,7 @@ import fixtures.ITRegistrationFixtures
 import itutil.IntegrationSpecBase
 import models.external.upscan.{InProgress, UpscanDetails, UpscanResponse}
 import play.api.libs.json.{JsObject, JsString, Json}
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import support.AppAndStubs
 import uk.gov.hmrc.http.{InternalServerException, NotFoundException, Upstream5xxResponse}
@@ -58,14 +59,15 @@ class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITR
 
 
   "upscanInitiate" must {
+    implicit val rq = FakeRequest()
     "return an UpscanResponse" in {
       stubPost(upscanInitiateUrl, OK, testUpscanResponseJson.toString())
       val requestBody = Json.obj(
         "callbackUrl" -> appConfig.storeUpscanCallbackUrl,
-        "successRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.url,
+        "successRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.absoluteURL(),
+        "errorRedirect" -> controllers.test.routes.FileUploadController.callbackCheck.absoluteURL(),
         "minimumFileSize" -> 0,
-        "maximumFileSize" -> 10485760,
-        "expectedContentType" -> "image/jpeg")
+        "maximumFileSize" -> 10485760)
 
       val response = await(connector.upscanInitiate())
 

--- a/test/connectors/mocks/MockUpscanConnector.scala
+++ b/test/connectors/mocks/MockUpscanConnector.scala
@@ -23,6 +23,7 @@ import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.Suite
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import scala.concurrent.Future
@@ -33,7 +34,7 @@ trait MockUpscanConnector extends MockitoSugar {
   val mockUpscanConnector: UpscanConnector = mock[UpscanConnector]
 
   def mockUpscanInitiate(res: Future[UpscanResponse]): OngoingStubbing[Future[UpscanResponse]] =
-    when(mockUpscanConnector.upscanInitiate()(ArgumentMatchers.any[HeaderCarrier])).thenReturn(res)
+    when(mockUpscanConnector.upscanInitiate()(ArgumentMatchers.any[HeaderCarrier], ArgumentMatchers.any[Request[AnyContent]])).thenReturn(res)
 
   def mockStoreUpscanReference(regId: String, reference: String)(res: Future[HttpResponse]): OngoingStubbing[Future[HttpResponse]] =
     when(mockUpscanConnector.storeUpscanReference(

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -19,6 +19,7 @@ package services
 import connectors.mocks.MockUpscanConnector
 import models.external.upscan.{InProgress, UpscanDetails, UpscanResponse}
 import play.api.http.Status._
+import play.api.test.FakeRequest
 import testHelpers.VatRegSpec
 import uk.gov.hmrc.http.{HttpResponse, InternalServerException}
 
@@ -34,6 +35,7 @@ class UpscanServiceSpec extends VatRegSpec with MockUpscanConnector {
   val testUpscanDetails: UpscanDetails = UpscanDetails(reference = testReference, fileStatus = InProgress)
 
   "initiateUpscan" must {
+    implicit val rq = FakeRequest()
     "return an UpscanResponse" in {
       mockUpscanInitiate(Future.successful(testUpscanResponse))
       mockStoreUpscanReference(testRegId, testReference)(Future.successful(HttpResponse(OK, "{}")))


### PR DESCRIPTION
SAR-9234 [VRS-FE] Update Upscan test page to allow only supported file types

**New feature**

- restrict file types upload in Upscan 
- remove redundant parameter in Upscan call

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [ ] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
