### PR TITLE
SAR-9532| Update missing postcode error handling to use country name instead of code

### DIFF
--- a/app/common/validators/AddressFormResultsHandler.scala
+++ b/app/common/validators/AddressFormResultsHandler.scala
@@ -50,7 +50,7 @@ class AddressFormResultsHandler @Inject()(view: CaptureInternationalAddress)
       formWithErrors => {
         val maybeCountryName = formWithErrors(countryField).value
         val finalForm = if (missingPostcode(maybeCountryName, formWithErrors(postcodeField).value)) {
-          formWithErrors.withError(postcodeField, postcodeRequiredErrorKey, getCountryCode(countries, maybeCountryName))
+          formWithErrors.withError(postcodeField, postcodeRequiredErrorKey, getCountryName(countries, maybeCountryName))
         } else {
           formWithErrors
         }
@@ -61,7 +61,7 @@ class AddressFormResultsHandler @Inject()(view: CaptureInternationalAddress)
         if (missingPostcode(maybeCountryName, internationalAddress.postcode)) {
           Future.successful(BadRequest(view(
             internationalAddressForm = addressForm.fill(internationalAddress).withError(
-              postcodeField, postcodeRequiredErrorKey, getCountryCode(countries, maybeCountryName)
+              postcodeField, postcodeRequiredErrorKey, getCountryName(countries, maybeCountryName)
             ),
             countries = countries.flatMap(_.name),
             submitAction = submitAction,
@@ -79,13 +79,13 @@ class AddressFormResultsHandler @Inject()(view: CaptureInternationalAddress)
     maybeCountry.nonEmpty && postcodeRequiredCountries.contains(maybeCountry.get) && maybePostcode.isEmpty
   }
 
-  private[validators] def getCountryCode(countries: Seq[Country], maybeCountryName: Option[String]): String = {
+  private[validators] def getCountryName(countries: Seq[Country], maybeCountryName: Option[String]): String = {
     val countryName = maybeCountryName.getOrElse(
       throw new InternalServerException("[AddressFormResultsHandler] Missing country name")
     )
 
-    countries.find(_.name.contains(countryName)).flatMap(_.code).getOrElse(
-      throw new InternalServerException(s"[AddressFormResultsHandler] Missing country code for '$countryName' country")
+    countries.find(_.name.contains(countryName)).flatMap(_.name).getOrElse(
+      throw new InternalServerException(s"[AddressFormResultsHandler] Missing country mapping for '$countryName'")
     )
   }
 }

--- a/conf/countries-en.json
+++ b/conf/countries-en.json
@@ -1827,7 +1827,7 @@
     "entry-number": "149",
     "entry-timestamp": "2016-04-05T13:23:05Z",
     "item-hash": "sha-256:34096f96f68fb8fa37a92e0f42e33a14ccf82a11660d05b015357ad1fd407535",
-    "country": "GG",
+    "country": "IM",
     "official-name": "Isle of Man",
     "name": "Isle of Man",
     "citizen-names": "British"

--- a/test/common/validators/AddressFormResultsHandlerSpec.scala
+++ b/test/common/validators/AddressFormResultsHandlerSpec.scala
@@ -32,13 +32,11 @@ class AddressFormResultsHandlerSpec extends VatRegSpec with Matchers {
     "return successfully if country config available in countries list" in {
       val resultsHandler = new AddressFormResultsHandler(app.injector.instanceOf[CaptureInternationalAddress])
 
-      val country = Some("United Kingdom")
-      val expectedCountryCode = "UK"
+      val expectedCountryName = "United Kingdom"
+      val testCountriesList = List(Country(Some("UK"), Some(expectedCountryName)))
+      val actualCountryName = resultsHandler.getCountryName(testCountriesList, Some(expectedCountryName))
 
-      val testCountriesList = List(Country(Some(expectedCountryCode), country))
-      val actualCountryCode = resultsHandler.getCountryCode(testCountriesList, country)
-
-      actualCountryCode mustBe expectedCountryCode
+      actualCountryName mustBe expectedCountryName
     }
 
     "fail if given country name is empty" in {
@@ -46,23 +44,23 @@ class AddressFormResultsHandlerSpec extends VatRegSpec with Matchers {
       val testCountriesList = List(Country(Some("UK"), Some("United Kingdom")))
 
       val caught = intercept[InternalServerException] {
-        resultsHandler.getCountryCode(testCountriesList, None)
+        resultsHandler.getCountryName(testCountriesList, None)
       }
 
       caught.getMessage mustBe "[AddressFormResultsHandler] Missing country name"
     }
 
-    "fail if given country name has no code configured" in {
+    "fail if given country name mapping is missing" in {
       val resultsHandler = new AddressFormResultsHandler(app.injector.instanceOf[CaptureInternationalAddress])
 
-      val country = Some("United Kingdom")
-      val testCountriesList = List(Country(None, country))
+      val country = "missing-country"
+      val testCountriesList = List(Country(Some("UK"), Some("United Kingdom")))
 
       val caught = intercept[InternalServerException] {
-        resultsHandler.getCountryCode(testCountriesList, country)
+        resultsHandler.getCountryName(testCountriesList, Some(country))
       }
 
-      caught.getMessage mustBe s"[AddressFormResultsHandler] Missing country code for '${country.get}' country"
+      caught.getMessage mustBe s"[AddressFormResultsHandler] Missing country mapping for '$country'"
     }
   }
 }


### PR DESCRIPTION
Update postcode missing error message to include country name instead of country code.

**Bug fix**

[SAR-9532](https://jira.tools.tax.service.gov.uk/browse/SAR-9532)

## Checklist

* [X] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
