### PR TITLE
SAR-9785 | Fix line1/line2 empty field validation

### DIFF
--- a/test/forms/InternationalAddressFormSpec.scala
+++ b/test/forms/InternationalAddressFormSpec.scala
@@ -74,6 +74,16 @@ class InternationalAddressFormSpec extends VatRegSpec with VatRegistrationFixtur
 
           res.errors.headOption.map(_.message) mustBe Some("internationalAddress.error.line1.empty")
         }
+        "line 1 isn't provided with form bound value being empty" in {
+          when(mockConfigConnector.countries).thenReturn(Seq(Country(Some("NO"), Some("Norway"))))
+
+          val res = form.bind(Map(
+            "line1" -> "",
+            "country" -> "Norway"
+          ))
+
+          res.errors.headOption.map(_.message) mustBe Some("internationalAddress.error.line1.empty")
+        }
         "line 1 is too long" in {
           when(mockConfigConnector.countries).thenReturn(Seq(Country(Some("NO"), Some("Norway"))))
 
@@ -103,6 +113,17 @@ class InternationalAddressFormSpec extends VatRegSpec with VatRegistrationFixtur
 
           val res = form.bind(Map(
             "line1" -> testLine1,
+            "country" -> "Norway"
+          ))
+
+          res.errors.headOption.map(_.message) mustBe Some("internationalAddress.error.line2.empty")
+        }
+        "line 2 isn't provided with form bound value being empty" in {
+          when(mockConfigConnector.countries).thenReturn(Seq(Country(Some("NO"), Some("Norway"))))
+
+          val res = form.bind(Map(
+            "line1" -> testLine1,
+            "line2" -> "",
             "country" -> "Norway"
           ))
 


### PR DESCRIPTION
[SAR-9785](https://jira.tools.tax.service.gov.uk/browse/SAR-9785)

Fix line1/line2 fields of international form validation, check for empty values.

**Bug fix**

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
