### PR TITLE
SAR-9870|Add vat representative section to upload document form hint builder

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -345,4 +345,5 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, runModeCon
   lazy val upscanTimeout = 20000
   lazy val upscanInterval = 2000
   lazy val VATRateDifferentGoodsURL = "https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services"
+  lazy val vat1trLink = "https://www.gov.uk/government/publications/vat-appointment-of-tax-representative-vat1tr"
 }

--- a/app/viewmodels/UploadDocumentHintBuilder.scala
+++ b/app/viewmodels/UploadDocumentHintBuilder.scala
@@ -78,6 +78,8 @@ class UploadDocumentHintBuilder @Inject()(applicantDetailsService: ApplicantDeta
         Future.successful(supplementDocumentUploadHint(appConfig.vat5LLink, "vat5LLink"))
       case VAT2 =>
         Future.successful(supplementDocumentUploadHint(appConfig.vat2Link, "vat2Link"))
+      case TaxRepresentativeAuthorisation =>
+        Future.successful(supplementDocumentUploadHint(appConfig.vat1trLink, "vat1trLink"))
       case _ =>
         throw new InternalServerException("Attachment Type not recognised")
     }

--- a/conf/messages
+++ b/conf/messages
@@ -1514,6 +1514,7 @@ supplementary.uploadDocument.start                   = Upload a completed
 supplementary.uploadDocument.vat5LLink               = VAT5L form
 supplementary.uploadDocument.vat51Link               = VAT 50/51 form
 supplementary.uploadDocument.vat2Link                = VAT2 form
+supplementary.uploadDocument.vat1trLink              = VAT1TR form
 
 # UPLOAD FORM ERROR MESSAGES
 fileUpload.async.error.page.heading                  = There is a problem with the selected file

--- a/test/viewmodels/UploadDocumentHintBuilderSpec.scala
+++ b/test/viewmodels/UploadDocumentHintBuilderSpec.scala
@@ -191,6 +191,7 @@ class UploadDocumentHintBuilderSpec extends VatRegSpec with MockApplicantDetails
         await(Builder.build(VAT5L)) mustBe expectedHtml(appConfig.vat5LLink, "vat5LLink")
         await(Builder.build(VAT51)) mustBe expectedHtml(appConfig.vat51Link, "vat51Link")
         await(Builder.build(VAT2)) mustBe expectedHtml(appConfig.vat2Link, "vat2Link")
+        await(Builder.build(TaxRepresentativeAuthorisation)) mustBe expectedHtml(appConfig.vat1trLink, "vat1trLink")
       }
     }
   }


### PR DESCRIPTION
# [SAR-9870](https://jira.tools.tax.service.gov.uk/browse/SAR-9870)

**New feature**

Tax representative form hint builder changes.

**Do Not Merge**
[SAR-9869](https://jira.tools.tax.service.gov.uk/browse/SAR-9869) is prerequisite to this story. 

## Checklist

* [X] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
