### PR TITLE
SAR-10037 | Change submit button to 'Save and continue' for international address pages

### DIFF
--- a/app/views/CaptureInternationalAddress.scala.html
+++ b/app/views/CaptureInternationalAddress.scala.html
@@ -111,7 +111,7 @@
             defaultOptionText = messages("internationalAddress.country.default")
         )
 
-        @button(messages("internationalAddress.submit"), showSaveProgressButton = true)
+        @button(messages("app.common.continue"), showSaveProgressButton = true)
     }
 
 }

--- a/conf/messages
+++ b/conf/messages
@@ -1121,7 +1121,6 @@ internationalAddress.line5                               = Address line 5 (optio
 internationalAddress.postcode                            = Postcode (optional)
 internationalAddress.country                             = Country
 internationalAddress.country.default                     = Select a country
-internationalAddress.submit                              = Continue
 internationalAddress.error.line1.empty                   = Enter address line 1
 internationalAddress.error.line1.length                  = Enter line 1 using 35 characters or less
 internationalAddress.error.line1.invalid                 = Enter line 1 without special characters

--- a/test/views/CaptureInternationalAddressViewSpec.scala
+++ b/test/views/CaptureInternationalAddressViewSpec.scala
@@ -39,7 +39,7 @@ class CaptureInternationalAddressViewSpec extends VatRegViewSpec {
     val line5 = "Address line 5 (optional)"
     val postcode = "Postcode (optional)"
     val country = "Country"
-    val continue = "Continue"
+    val saveAndContinue = "Save and continue"
   }
 
   val transactorDoc = Jsoup.parse(view(form, Seq(), submitAction = Call("GET", "/"), headingKey = "internationalAddress.home.3pt.heading", name = testTransactorName).body)
@@ -77,7 +77,7 @@ class CaptureInternationalAddressViewSpec extends VatRegViewSpec {
       doc.select("label[for=country]").toList.headOption.map(_.text) mustBe Some(ExpectedMessages.country)
     }
     "have a submit button" in new ViewSetup {
-      doc.submitButton mustBe Some(ExpectedMessages.continue)
+      doc.submitButton mustBe Some(ExpectedMessages.saveAndContinue)
     }
   }
 


### PR DESCRIPTION
[SAR-10037](https://jira.tools.tax.service.gov.uk/browse/SAR-10037)

**Bug fix**

Change submit button on international address pages to "Save and continue"

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
