### PR TITLE
SAR-10070 | Upgrade hmrc-mongo-play-28 to latest version

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ object AppDependencies {
 }
 
 private object CompileDependencies {
-  private val hmrcMongoVersion = "0.65.0"
+  private val hmrcMongoVersion = "0.68.0"
   private val bootstrapVersion = "5.20.0"
   private val timeVersion = "3.25.0"
   private val partialsVersion = "8.3.0-play-28"


### PR DESCRIPTION
[SAR-10070](https://jira.tools.tax.service.gov.uk/browse/SAR-10070)

Upgrade hmrc-mongo-play library to latest version (0.68.0)

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
