### PR TITLE
SAR-10084 | Attachments service tidup and migration to use registration api connector

### DIFF
--- a/app/connectors/AttachmentsConnector.scala
+++ b/app/connectors/AttachmentsConnector.scala
@@ -17,9 +17,8 @@
 package connectors
 
 import config.FrontendAppConfig
-import models.api.{AttachmentMethod, AttachmentType, Attachments}
+import models.api.AttachmentType
 import play.api.http.Status._
-import play.api.libs.json.{Format, JsValue, Json}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse, InternalServerException}
 
 import javax.inject.{Inject, Singleton}
@@ -28,22 +27,19 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AttachmentsConnector @Inject()(httpClient: HttpClient, config: FrontendAppConfig)(implicit ec: ExecutionContext) {
 
-  def getAttachmentList(regId: String)(implicit hc: HeaderCarrier): Future[Attachments] = {
+  def getAttachmentList(regId: String)(implicit hc: HeaderCarrier): Future[List[AttachmentType]] = {
     implicit val readRaw: HttpReads[HttpResponse] = HttpReads.Implicits.readRaw
 
     httpClient.GET[HttpResponse](config.attachmentsApiUrl(regId)).map { result =>
       result.status match {
-        case OK => result.json.validate[Attachments].get
+        case OK =>
+          result.json.validate[List[AttachmentType]].orElse(
+            (result.json \ "attachments").validate[List[AttachmentType]] // Remove this as part of cleanup task
+          ).getOrElse(throw new InternalServerException("[AttachmentsConnector][getAttachmentList] failed to parse attachment list response"))
         case status => throw new InternalServerException(s"[AttachmentsConnector][getAttachmentList] unexpected status from backend: $status")
       }
     }
   }
-
-  def storeAttachmentDetails(regId: String, attachmentMethod: AttachmentMethod)(implicit hc: HeaderCarrier): Future[JsValue] =
-    httpClient.PUT[JsValue, JsValue] (
-      url = config.attachmentsApiUrl(regId),
-      body = Json.obj("method" -> Json.toJson(attachmentMethod))
-    )
 
   def getIncompleteAttachments(regId: String)(implicit hc: HeaderCarrier): Future[List[AttachmentType]] = {
     implicit val readRaw: HttpReads[HttpResponse] = HttpReads.Implicits.readRaw

--- a/app/controllers/ApplicationSubmissionController.scala
+++ b/app/controllers/ApplicationSubmissionController.scala
@@ -43,12 +43,13 @@ class ApplicationSubmissionController @Inject()(val vatRegistrationService: VatR
     implicit request =>
       implicit profile =>
         for {
-          attachmentsList <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachments <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachmentDetails <- attachmentsService.getAttachmentDetails(profile.registrationId)
           acknowledgementRef <- vatRegistrationService.getAckRef(profile.registrationId)
           prefix = acknowledgementRef.take(prefixLength)
           groups = acknowledgementRef.drop(prefixLength).grouped(groupSize).toList
           formattedRef = prefix +: groups mkString separator
-        } yield Ok(applicationSubmissionConfirmationView(formattedRef, attachmentsList.method, attachmentsList.attachments.nonEmpty))
+        } yield Ok(applicationSubmissionConfirmationView(formattedRef, attachmentDetails.flatMap(_.method), attachments.nonEmpty))
   }
 
   def submit: Action[AnyContent] = isAuthenticated {

--- a/app/controllers/attachments/AttachmentMethodController.scala
+++ b/app/controllers/attachments/AttachmentMethodController.scala
@@ -39,8 +39,8 @@ class AttachmentMethodController @Inject()(val authConnector: AuthClientConnecto
                                            baseControllerComponents: BaseControllerComponents) extends BaseController with SessionProfile {
 
   def show: Action[AnyContent] = isAuthenticatedWithProfile() { implicit request => implicit profile =>
-    attachmentsService.getAttachmentList(profile.registrationId).map {
-      case Attachments(Some(method), _) =>
+    attachmentsService.getAttachmentDetails(profile.registrationId).map {
+      case Some(Attachments(Some(method))) =>
         Ok(view(form().fill(method)))
       case _ =>
         Ok(view(form()))

--- a/app/controllers/attachments/DocumentsRequiredController.scala
+++ b/app/controllers/attachments/DocumentsRequiredController.scala
@@ -39,9 +39,9 @@ class DocumentsRequiredController @Inject()(val authConnector: AuthClientConnect
     implicit request =>
       implicit profile =>
         for {
-          attachmentInfo <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachments <- attachmentsService.getAttachmentList(profile.registrationId)
           isTransactor <- vatRegistrationService.isTransactor
-          redirect = attachmentInfo.attachments match {
+          redirect = attachments match {
             case Nil =>
               Redirect(controllers.routes.SummaryController.show)
             case list if isTransactor && list.forall(List(IdentityEvidence, TransactorIdentityEvidence).contains(_)) =>

--- a/app/controllers/attachments/EmailCoverSheetController.scala
+++ b/app/controllers/attachments/EmailCoverSheetController.scala
@@ -46,7 +46,7 @@ class EmailCoverSheetController @Inject()(view: EmailCoverSheet,
     implicit request =>
       implicit profile =>
         for {
-          attachmentsList <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachments <- attachmentsService.getAttachmentList(profile.registrationId)
           acknowledgementRef <- vatRegistrationService.getAckRef(profile.registrationId)
           prefix = acknowledgementRef.take(prefixLength)
           groups = acknowledgementRef.drop(prefixLength).grouped(groupSize).toList
@@ -62,6 +62,6 @@ class EmailCoverSheetController @Inject()(view: EmailCoverSheet,
           } else {
             Future.successful(None)
           }
-        } yield Ok(view(formattedRef, attachmentsList.attachments, applicantName, transactorName))
+        } yield Ok(view(formattedRef, attachments, applicantName, transactorName))
   }
 }

--- a/app/controllers/attachments/MultipleDocumentsRequiredController.scala
+++ b/app/controllers/attachments/MultipleDocumentsRequiredController.scala
@@ -42,7 +42,7 @@ class MultipleDocumentsRequiredController @Inject()(val authConnector: AuthClien
     implicit request =>
       implicit profile =>
         for {
-          attachmentInfo <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachments <- attachmentsService.getAttachmentList(profile.registrationId)
           isTransactor <- vatRegistrationService.isTransactor
           applicantName <- if (isTransactor) {
             applicantDetailsService.getApplicantDetails.map(_.personalDetails.map(_.fullName))
@@ -54,7 +54,7 @@ class MultipleDocumentsRequiredController @Inject()(val authConnector: AuthClien
           } else {
             Future.successful(None)
           }
-        } yield Ok(multipleDocumentsRequiredPage(attachmentInfo.attachments, applicantName, transactorName))
+        } yield Ok(multipleDocumentsRequiredPage(attachments, applicantName, transactorName))
   }
 
 }

--- a/app/controllers/attachments/PostalCoverSheetController.scala
+++ b/app/controllers/attachments/PostalCoverSheetController.scala
@@ -46,7 +46,7 @@ class PostalCoverSheetController @Inject()(view: PostalCoverSheet,
     implicit request =>
       implicit profile =>
         for {
-          attachmentsList <- attachmentsService.getAttachmentList(profile.registrationId)
+          attachments <- attachmentsService.getAttachmentList(profile.registrationId)
           acknowledgementRef <- vatRegistrationService.getAckRef(profile.registrationId)
           prefix = acknowledgementRef.take(prefixLength)
           groups = acknowledgementRef.drop(prefixLength).grouped(groupSize).toList
@@ -62,6 +62,6 @@ class PostalCoverSheetController @Inject()(view: PostalCoverSheet,
           } else {
             Future.successful(None)
           }
-        } yield Ok(view(formattedRef, attachmentsList.attachments, applicantName, transactorName))
+        } yield Ok(view(formattedRef, attachments, applicantName, transactorName))
   }
 }

--- a/app/models/api/Attachments.scala
+++ b/app/models/api/Attachments.scala
@@ -16,12 +16,14 @@
 
 package models.api
 
+import models.ApiKey
 import play.api.libs.json._
 
 
-case class Attachments(method: Option[AttachmentMethod], attachments: List[AttachmentType])
+case class Attachments(method: Option[AttachmentMethod] = None)
 
 object Attachments {
+  implicit val apiKey: ApiKey[Attachments] = ApiKey("attachments")
   implicit val format: Format[Attachments] = Json.format[Attachments]
 }
 

--- a/app/services/AttachmentsService.scala
+++ b/app/services/AttachmentsService.scala
@@ -16,22 +16,25 @@
 
 package services
 
-import connectors.AttachmentsConnector
+import connectors.{AttachmentsConnector, RegistrationApiConnector}
 import models.api.{AttachmentMethod, AttachmentType, Attachments}
-import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AttachmentsService @Inject()(val attachmentsConnector: AttachmentsConnector)
-                                  (implicit ec: ExecutionContext) {
+class AttachmentsService @Inject()(val attachmentsConnector: AttachmentsConnector,
+                                   registrationApiConnector: RegistrationApiConnector
+                                  )(implicit ec: ExecutionContext) {
 
-  def getAttachmentList(regId: String)(implicit hc: HeaderCarrier): Future[Attachments] =
+  def getAttachmentDetails(regId: String)(implicit hc: HeaderCarrier): Future[Option[Attachments]] =
+    registrationApiConnector.getSection[Attachments](regId)
+
+  def storeAttachmentDetails(regId: String, method: AttachmentMethod)(implicit hc: HeaderCarrier): Future[Attachments] =
+    registrationApiConnector.replaceSection[Attachments](regId, Attachments(method = Some(method)))
+
+  def getAttachmentList(regId: String)(implicit hc: HeaderCarrier): Future[List[AttachmentType]] =
     attachmentsConnector.getAttachmentList(regId)
-
-  def storeAttachmentDetails(regId: String, method: AttachmentMethod)(implicit hc: HeaderCarrier): Future[JsValue] =
-    attachmentsConnector.storeAttachmentDetails(regId, method)
 
   def getIncompleteAttachments(regId: String)(implicit hc: HeaderCarrier): Future[List[AttachmentType]] =
     attachmentsConnector.getIncompleteAttachments(regId)

--- a/it/controllers/attachments/AttachmentMethodControllerISpec.scala
+++ b/it/controllers/attachments/AttachmentMethodControllerISpec.scala
@@ -13,15 +13,13 @@ import play.api.test.Helpers._
 class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistrationFixtures {
 
   val url = "/attachment-method"
-  val emptyAttachmentList = Attachments(None, List())
-  val fullAttachmentList = Attachments(Some(Post), List(IdentityEvidence))
+  val fullAttachmentList = Attachments(Some(Post))
 
   "GET /register-for-vat/attachment-method" when {
     "the backend contains no attachment information" must {
       "return OK and render the page with a blank form" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.has("attachments", Json.toJson(emptyAttachmentList))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -37,7 +35,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
       "return OK and render the page with the Post option selected" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.has("attachments", Json.toJson(fullAttachmentList))
+          .registrationApi.getSection[Attachments](Some(fullAttachmentList))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -53,7 +51,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
       "return OK and render the page with the Email option selected" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.has("attachments", Json.toJson(fullAttachmentList.copy(method = Some(EmailMethod))))
+          .registrationApi.getSection[Attachments](Some(fullAttachmentList.copy(method = Some(EmailMethod))))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -70,7 +68,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
         enable(UploadDocuments)
         given
           .user.isAuthorised()
-          .vatScheme.has("attachments", Json.toJson(fullAttachmentList.copy(method = Some(Attached))))
+          .registrationApi.getSection[Attachments](Some(fullAttachmentList.copy(method = Some(Attached))))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -91,7 +89,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
         enable(UploadDocuments)
         given
           .user.isAuthorised()
-          .vatScheme.storesAttachments(Attachments(Some(Attached), List()))
+          .registrationApi.replaceSection[Attachments](Attachments(Some(Attached)))
           .vatScheme.deleteAttachments
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -109,7 +107,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
       "store the answer and redirect to the next page" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.storesAttachments(Attachments(Some(Post), List()))
+          .registrationApi.replaceSection[Attachments](Attachments(Some(Post)))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -125,7 +123,7 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
       "store the answer and redirect to the next page" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.storesAttachments(Attachments(Some(Post), List()))
+          .registrationApi.replaceSection[Attachments](Attachments(Some(EmailMethod)))
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
@@ -154,7 +152,8 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
       "return BAD_REQUEST" in new Setup {
         given
           .user.isAuthorised()
-          .vatScheme.storesAttachments(Attachments(Some(Other), List()))
+          .registrationApi.replaceSection[Attachments](Attachments(Some(Other)))
+
 
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 

--- a/it/controllers/attachments/DocumentsRequiredControllerISpec.scala
+++ b/it/controllers/attachments/DocumentsRequiredControllerISpec.scala
@@ -13,10 +13,11 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
   val submitUrl: String = routes.DocumentsRequiredController.submit.url
 
   s"GET $resolveUrl" must {
-    "return a redirect to documents required page when identity evidence is required and method is Other" in {
+
+    "return a redirect to documents required page when identity evidence is required" in {
       given()
         .user.isAuthorised()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Other), List[AttachmentType](IdentityEvidence))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -27,40 +28,12 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
       }
     }
 
-    "return a redirect to documents required page when identity evidence is required and method is Attached" in {
-      given()
-        .user.isAuthorised()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Attached), List[AttachmentType](IdentityEvidence))))
-        .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
-
-      val res = buildClient(resolveUrl).get()
-
-      whenReady(res) { result =>
-        result.status mustBe SEE_OTHER
-        result.header(HeaderNames.LOCATION) mustBe Some(controllers.attachments.routes.IdentityEvidenceRequiredController.show.url)
-      }
-    }
-
-    "return a redirect to documents required page when identity evidence is required and method is Post" in {
-      given()
-        .user.isAuthorised()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](IdentityEvidence))))
-        .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
-
-      val res = buildClient(resolveUrl).get()
-
-      whenReady(res) { result =>
-        result.status mustBe SEE_OTHER
-        result.header(HeaderNames.LOCATION) mustBe Some(controllers.attachments.routes.IdentityEvidenceRequiredController.show.url)
-      }
-    }
-
-    "return a redirect to VAT2 required page when VAT2 is required and method is Post" in {
+    "return a redirect to VAT2 required page when VAT2 is required" in {
       given()
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](VAT2)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -76,7 +49,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](VAT51))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](VAT51)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -92,7 +65,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](VAT5L))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](VAT5L)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -108,7 +81,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](TaxRepresentativeAuthorisation))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](TaxRepresentativeAuthorisation)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -124,7 +97,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](VAT5L, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](VAT5L, VAT2)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()
@@ -141,7 +114,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
           .user.isAuthorised()
           .audit.writesAudit()
           .audit.writesAuditMerged()
-          .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](TransactorIdentityEvidence))))
+          .vatScheme.has("attachments", Json.toJson(List[AttachmentType](TransactorIdentityEvidence)))
           .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
 
         val res = buildClient(resolveUrl).get()
@@ -157,7 +130,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
           .user.isAuthorised()
           .audit.writesAudit()
           .audit.writesAuditMerged()
-          .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](IdentityEvidence))))
+          .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence)))
           .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
 
         val res = buildClient(resolveUrl).get()
@@ -173,7 +146,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
           .user.isAuthorised()
           .audit.writesAudit()
           .audit.writesAuditMerged()
-          .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType](TransactorIdentityEvidence, IdentityEvidence))))
+          .vatScheme.has("attachments", Json.toJson(List[AttachmentType](TransactorIdentityEvidence, IdentityEvidence)))
           .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
 
         val res = buildClient(resolveUrl).get()
@@ -188,7 +161,7 @@ class DocumentsRequiredControllerISpec extends ControllerISpec {
     "return a redirect to summary page when no attachments are given" in {
       given()
         .user.isAuthorised()
-        .vatScheme.has("attachments", Json.toJson(Attachments(None, List[AttachmentType]())))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType]()))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       val res = buildClient(resolveUrl).get()

--- a/it/controllers/attachments/EmailCoverSheetControllerISpec.scala
+++ b/it/controllers/attachments/EmailCoverSheetControllerISpec.scala
@@ -37,7 +37,7 @@ class EmailCoverSheetControllerISpec extends ControllerISpec with ITRegistration
       given()
         .user.isAuthorised()
         .vatScheme.has("acknowledgement-reference", JsString(s"$testAckRef"))
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(EmailMethod), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -53,7 +53,7 @@ class EmailCoverSheetControllerISpec extends ControllerISpec with ITRegistration
       given()
         .user.isAuthorised()
         .vatScheme.has("acknowledgement-reference", JsString(s"$testAckRef"))
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(EmailMethod), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[TransactorDetails](Some(validTransactorDetails))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
         .registrationApi.getSection[ApplicantDetails](Some(validFullApplicantDetails))

--- a/it/controllers/attachments/MultipleDocumentsRequiredControllerISpec.scala
+++ b/it/controllers/attachments/MultipleDocumentsRequiredControllerISpec.scala
@@ -17,7 +17,7 @@ class MultipleDocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -35,7 +35,7 @@ class MultipleDocumentsRequiredControllerISpec extends ControllerISpec {
         .user.isAuthorised()
         .audit.writesAudit()
         .audit.writesAuditMerged()
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[TransactorDetails](Some(validTransactorDetails))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
         .registrationApi.getSection[ApplicantDetails](Some(validFullApplicantDetails))

--- a/it/controllers/attachments/PostalCoverSheetControllerISpec.scala
+++ b/it/controllers/attachments/PostalCoverSheetControllerISpec.scala
@@ -37,7 +37,7 @@ class PostalCoverSheetControllerISpec extends ControllerISpec with ITRegistratio
       given()
         .user.isAuthorised()
         .vatScheme.has("acknowledgement-reference", JsString(s"$testAckRef"))
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData))
 
       insertCurrentProfileIntoDb(currentProfile, sessionId)
@@ -53,7 +53,7 @@ class PostalCoverSheetControllerISpec extends ControllerISpec with ITRegistratio
       given()
         .user.isAuthorised()
         .vatScheme.has("acknowledgement-reference", JsString(s"$testAckRef"))
-        .vatScheme.has("attachments", Json.toJson(Attachments(Some(Post), List[AttachmentType](IdentityEvidence, VAT2))))
+        .vatScheme.has("attachments", Json.toJson(List[AttachmentType](IdentityEvidence, VAT2)))
         .registrationApi.getSection[TransactorDetails](Some(validTransactorDetails))
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(isTransactor = true)))
         .registrationApi.getSection[ApplicantDetails](Some(validFullApplicantDetails))

--- a/test/connectors/AttachmentsConnectorSpec.scala
+++ b/test/connectors/AttachmentsConnectorSpec.scala
@@ -32,14 +32,6 @@ class AttachmentsConnectorSpec extends VatRegSpec {
 
   val testEmptyAttachmentList: List[AttachmentType] = List[AttachmentType]()
 
-  val testAttachments: Attachments = Attachments(None, testAttachmentList)
-
-  val testEmptyAttachments: Attachments = Attachments(None, testEmptyAttachmentList)
-
-  val testIncompleteAttachments: Attachments = Attachments(None, testAttachmentList)
-
-  val testEmptyIncompleteAttachments: Attachments = Attachments(None, testEmptyAttachmentList)
-
   val testStoreAttachmentsOtherResponseJson: JsObject = Json.obj(
     "method" -> Some(Other).toString,
   )
@@ -52,19 +44,19 @@ class AttachmentsConnectorSpec extends VatRegSpec {
 
   "getAttachments" should {
     "return a list of attachments" in {
-      mockHttpGET(appConfig.attachmentsApiUrl(testRegId), HttpResponse(OK, Json.toJson(testAttachments).toString))
+      mockHttpGET(appConfig.attachmentsApiUrl(testRegId), HttpResponse(OK, Json.toJson(testAttachmentList).toString))
 
       val result = connector.getAttachmentList(testRegId)
 
-      await(result) mustBe testAttachments
+      await(result) mustBe testAttachmentList
     }
 
     "return an empty list of attachments" in {
-      mockHttpGET(appConfig.attachmentsApiUrl(testRegId), HttpResponse(OK, Json.toJson(Attachments(None, List[AttachmentType]())).toString()))
+      mockHttpGET(appConfig.attachmentsApiUrl(testRegId), HttpResponse(OK, Json.toJson(testEmptyAttachmentList).toString()))
 
       val result = connector.getAttachmentList(testRegId)
 
-      await(result) mustBe testEmptyAttachments
+      await(result) mustBe testEmptyAttachmentList
     }
 
     "throw an exception" in {
@@ -73,32 +65,6 @@ class AttachmentsConnectorSpec extends VatRegSpec {
       val result = connector.getAttachmentList(testRegId)
 
       intercept[InternalServerException](await(result)).message mustBe "[AttachmentsConnector][getAttachmentList] unexpected status from backend: 500"
-    }
-  }
-
-  "storeAttachmentDetails" should {
-    "return OK when method is Other" in {
-      mockHttpPUT(appConfig.attachmentsApiUrl(testRegId), testStoreAttachmentsOtherResponseJson)
-
-      val result = connector.storeAttachmentDetails(testRegId, Other)
-
-      await(result) mustBe testStoreAttachmentsOtherResponseJson
-    }
-
-    "return OK when method is Attached" in {
-      mockHttpPUT(appConfig.attachmentsApiUrl(testRegId), testStoreAttachmentsOtherResponseJson)
-
-      val result = connector.storeAttachmentDetails(testRegId, Attached)
-
-      await(result) mustBe testStoreAttachmentsOtherResponseJson
-    }
-
-    "return OK when method is Post" in {
-   mockHttpPUT(appConfig.attachmentsApiUrl(testRegId), testStoreAttachmentsOtherResponseJson)
-
-      val result = connector.storeAttachmentDetails(testRegId, Post)
-
-      await(result) mustBe testStoreAttachmentsOtherResponseJson
     }
   }
 

--- a/test/connectors/mocks/MockAttachmentsConnector.scala
+++ b/test/connectors/mocks/MockAttachmentsConnector.scala
@@ -17,13 +17,12 @@
 package connectors.mocks
 
 import connectors.AttachmentsConnector
-import models.api.{AttachmentMethod, AttachmentType, Attachments}
+import models.api.AttachmentType
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.Suite
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.libs.json.JsValue
 
 import scala.concurrent.Future
 
@@ -32,15 +31,9 @@ trait MockAttachmentsConnector extends MockitoSugar {
 
   val mockAttachmentsConnector = mock[AttachmentsConnector]
 
-  def mockGetAttachmentsList(regId: String)(response: Future[Attachments]): OngoingStubbing[Future[Attachments]] =
+  def mockGetAttachmentsList(regId: String)(response: Future[List[AttachmentType]]): OngoingStubbing[Future[List[AttachmentType]]] =
     when(mockAttachmentsConnector.getAttachmentList(ArgumentMatchers.eq(regId))(ArgumentMatchers.any()))
       .thenReturn(response)
-
-  def mockStoreAttachmentDetails(regId: String, method: AttachmentMethod)(response: Future[JsValue]): OngoingStubbing[Future[JsValue]] =
-    when(mockAttachmentsConnector.storeAttachmentDetails(
-      ArgumentMatchers.eq(regId),
-      ArgumentMatchers.eq(method)
-    )(ArgumentMatchers.any())).thenReturn(response)
 
   def mockGetIncompleteAttachments(regId: String)(response: Future[List[AttachmentType]]): OngoingStubbing[Future[List[AttachmentType]]] =
     when(mockAttachmentsConnector.getIncompleteAttachments(ArgumentMatchers.eq(regId))(ArgumentMatchers.any()))

--- a/test/controllers/ApplicationSubmissionControllerSpec.scala
+++ b/test/controllers/ApplicationSubmissionControllerSpec.scala
@@ -50,7 +50,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
         .thenReturn(Future.successful("123412341234"))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(None, List())))
+        .thenReturn(Future.successful(List()))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = None))))
 
       callAuthorised(testController.show) { res =>
         status(res) mustBe OK
@@ -62,7 +65,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(None, List(IdentityEvidence))))
+        .thenReturn(Future.successful(List(IdentityEvidence)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = None))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))
@@ -77,7 +83,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(Some(Other), List(IdentityEvidence))))
+        .thenReturn(Future.successful(List(IdentityEvidence)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = Some(Other)))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))
@@ -92,7 +101,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(Some(Attached), List(IdentityEvidence))))
+        .thenReturn(Future.successful(List(IdentityEvidence)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = Some(Attached)))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))
@@ -107,7 +119,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(Some(Post), List(IdentityEvidence))))
+        .thenReturn(Future.successful(List(IdentityEvidence)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = Some(Post)))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))
@@ -122,7 +137,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(Some(EmailMethod), List(IdentityEvidence))))
+        .thenReturn(Future.successful(List(IdentityEvidence)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = Some(EmailMethod)))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))
@@ -137,7 +155,10 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       mockWithCurrentProfile(Some(currentProfile))
 
       when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(Attachments(Some(Post), List(VAT51))))
+        .thenReturn(Future.successful(List(VAT51)))
+
+      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
+        .thenReturn(Future.successful(Some(Attachments(method = Some(Post)))))
 
       when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.id))(any()))
         .thenReturn(Future.successful("123412341234"))

--- a/test/models/api/AttachmentsSpec.scala
+++ b/test/models/api/AttachmentsSpec.scala
@@ -21,14 +21,11 @@ import testHelpers.VatRegSpec
 
 class AttachmentsSpec extends VatRegSpec {
 
-  val minimalModel = Attachments(method = None, attachments = List(IdentityEvidence))
-  val validMinimalJson = Json.obj("attachments" -> Json.arr("identityEvidence"))
+  val minimalModel = Attachments(method = None)
+  val validMinimalJson = Json.obj()
 
-  val fullModel = Attachments(method = Some(Post), attachments = List(IdentityEvidence))
-  val validFullJson = Json.obj(
-    "attachments" -> Json.arr("identityEvidence"),
-    "method" -> "3"
-  )
+  val fullModel = Attachments(method = Some(Post))
+  val validFullJson = Json.obj("method" -> "3")
 
   "the attachments model" must {
     "deserialize from minimal valid json" in {


### PR DESCRIPTION
[SAR-10084](https://jira.tools.tax.service.gov.uk/browse/SAR-10084)

- Separate attachments list from attachments model, and keep model matching to backend for just attachmentMethod
- Update attachment service to use registration api sections for attachment method
- Keep existing backend usage of attachment list for all and incomplete attachments.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
