### PR TITLE
SAR-XXXX | Update tasklist builder prerequisite check to chain prerequisites from tasklist rows

### DIFF
--- a/test/viewmodels/tasklist/AboutTheBusinessTaskListSpec.scala
+++ b/test/viewmodels/tasklist/AboutTheBusinessTaskListSpec.scala
@@ -153,17 +153,21 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
   }
 
   "The other business involvements row" must {
-    "be cannot start if the prerequesites are not complete" in {
-      val scheme = emptyVatScheme
-
-      val row = section.otherBusinessInvolvementsRow.build(scheme)
+    "be cannot start if the prerequisites are not complete" in {
+      val row = section.otherBusinessInvolvementsRow.build(emptyVatScheme)
 
       row.status mustBe TLCannotStart
       row.url mustBe controllers.otherbusinessinvolvements.routes.OtherBusinessInvolvementController.show.url
     }
 
-    "be not started if the prerequesites are complete but 'Is involved in other business' question is not answered" in {
-      val scheme = emptyVatScheme.copy(business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = None)))
+    "be not started if the prerequisites are complete but 'Is involved in other business' question is not answered" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = None
+        ))
+      )
 
       val row = section.otherBusinessInvolvementsRow.build(scheme)
 
@@ -171,8 +175,14 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
       row.url mustBe controllers.otherbusinessinvolvements.routes.OtherBusinessInvolvementController.show.url
     }
 
-    "be completed if the prerequesites are complete and 'Is involved in other business' question is answered as 'No'" in {
-      val scheme = emptyVatScheme.copy(business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = Some(false))))
+    "be completed if the prerequisites are complete and 'Is involved in other business' question is answered as 'No'" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = Some(false)
+        ))
+      )
 
       val row = section.otherBusinessInvolvementsRow.build(scheme)
 
@@ -180,9 +190,13 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
       row.url mustBe controllers.otherbusinessinvolvements.routes.OtherBusinessInvolvementController.show.url
     }
 
-    "be in progress if the prerequesites are complete and the other business involvements list is empty" in {
-      val scheme = emptyVatScheme.copy(
-        business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = Some(true))),
+    "be in progress if the prerequisites are complete and the other business involvements list is empty" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = Some(true)
+        )),
         otherBusinessInvolvements = Some(List.empty)
       )
 
@@ -192,9 +206,13 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
       row.url mustBe controllers.otherbusinessinvolvements.routes.OtherBusinessInvolvementController.show.url
     }
 
-    "be in progress if the prerequesites are complete and the other business involvements list is None" in {
-      val scheme = emptyVatScheme.copy(
-        business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = Some(true))),
+    "be in progress if the prerequisites are complete and the other business involvements list is None" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = Some(true)
+        )),
         otherBusinessInvolvements = None
       )
 
@@ -205,9 +223,13 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
     }
 
     "be in progress and redirect to other business involvements summary page " +
-      "if the prerequesites are complete and the other business involvements list has items with partial details" in {
-      val scheme = emptyVatScheme.copy(
-        business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = Some(true))),
+      "if the prerequisites are complete and the other business involvements list has items with partial details" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = Some(true)
+        )),
         otherBusinessInvolvements = Some(List(
           otherBusinessInvolvementWithPartialData,
           otherBusinessInvolvementWithVrn
@@ -221,9 +243,13 @@ class AboutTheBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixtur
     }
 
     "be completed and redirect to other business involvements summary page " +
-      "if the prerequesites are complete and the other business involvements list has items with required data" in {
-      val scheme = emptyVatScheme.copy(
-        business = Some(validBusiness.copy(hasLandAndProperty = Some(false), otherBusinessInvolvement = Some(true))),
+      "if the prerequisites are complete and the other business involvements list has items with required data" in {
+      val scheme = validVatScheme.copy(
+        business = Some(validBusiness.copy(
+          hasLandAndProperty = Some(false),
+          businessActivities = Some(List(sicCode)),
+          otherBusinessInvolvement = Some(true)
+        )),
         otherBusinessInvolvements = Some(List(
           otherBusinessInvolvementWithVrn,
           otherBusinessInvolvementWithUtr,

--- a/test/viewmodels/tasklist/AboutYouTaskListSpec.scala
+++ b/test/viewmodels/tasklist/AboutYouTaskListSpec.scala
@@ -612,10 +612,7 @@ class AboutYouTaskListSpec extends VatRegSpec with VatRegistrationFixture with F
     "address details available from prerequisite but contact details capture hasn't started" must {
       "return TLNotStarted" in {
         val scheme = emptyVatScheme.copy(
-          eligibilitySubmissionData = Some(validEligibilitySubmissionData.copy(
-            partyType = LtdPartnership,
-            isTransactor = false
-          )),
+          eligibilitySubmissionData = Some(validEligibilitySubmissionData),
           applicantDetails = Some(ApplicantDetails(
             entity = Some(testSoleTrader),
             personalDetails = Some(testPersonalDetails),
@@ -637,10 +634,7 @@ class AboutYouTaskListSpec extends VatRegSpec with VatRegistrationFixture with F
     "address details available from prerequisite but contact details still in progress" must {
       "return TLInProgress" in {
         val scheme = emptyVatScheme.copy(
-          eligibilitySubmissionData = Some(validEligibilitySubmissionData.copy(
-            partyType = Partnership,
-            isTransactor = false
-          )),
+          eligibilitySubmissionData = Some(validEligibilitySubmissionData),
           applicantDetails = Some(ApplicantDetails(
             entity = Some(testSoleTrader),
             personalDetails = Some(testPersonalDetails),
@@ -664,10 +658,7 @@ class AboutYouTaskListSpec extends VatRegSpec with VatRegistrationFixture with F
       "return TLCompleted" in {
 
         val scheme = emptyVatScheme.copy(
-          eligibilitySubmissionData = Some(validEligibilitySubmissionData.copy(
-            partyType = LtdPartnership,
-            isTransactor = false
-          )),
+          eligibilitySubmissionData = Some(validEligibilitySubmissionData),
           applicantDetails = Some(completeApplicantDetails)
         )
 

--- a/test/viewmodels/tasklist/RegistrationReasonTaskListSpec.scala
+++ b/test/viewmodels/tasklist/RegistrationReasonTaskListSpec.scala
@@ -18,7 +18,6 @@ package viewmodels.tasklist
 
 import fixtures.VatRegistrationFixture
 import testHelpers.VatRegSpec
-import viewmodels.tasklist.RegistrationReasonTaskList
 
 class RegistrationReasonTaskListSpec extends VatRegSpec with VatRegistrationFixture {
 
@@ -40,7 +39,7 @@ class RegistrationReasonTaskListSpec extends VatRegSpec with VatRegistrationFixt
 
   "registrationReasonRow prerequisites" must {
     "return true" in {
-      section.registrationReasonRow(testRegId).prerequisites(emptyVatScheme).forall(_.isComplete(emptyVatScheme)) mustBe true
+      section.registrationReasonRow(testRegId).prerequisitesMet(emptyVatScheme) mustBe true
     }
   }
 

--- a/test/viewmodels/tasklist/TaskListRowBuilderSpec.scala
+++ b/test/viewmodels/tasklist/TaskListRowBuilderSpec.scala
@@ -18,7 +18,6 @@ package viewmodels.tasklist
 
 import fixtures.VatRegistrationFixture
 import play.api.i18n.{Lang, Messages}
-import viewmodels.tasklist._
 import views.VatRegViewSpec
 import views.html.components.TaskListRow
 
@@ -83,6 +82,7 @@ class TaskListRowBuilderSpec extends VatRegViewSpec with VatRegistrationFixture 
         }
       }
     }
+
     "prerequisites haven't been met" must {
       "return CANNOT START" in {
         val testVatScheme = emptyVatScheme
@@ -92,6 +92,14 @@ class TaskListRowBuilderSpec extends VatRegViewSpec with VatRegistrationFixture 
         res mustBe TaskListSectionRow(rowMessageKey, testUrl, rowAriaLabel, TLCannotStart)
       }
     }
-  }
 
+    "current prerequisite met but chained prerequisite hasn't been met" must {
+      "return CANNOT START" in {
+        val chainedPrerequisite = testPrerequisite(checksPass = true).copy(prerequisites = _ => Seq(testPrerequisite(checksPass = false)))
+        val result = testPrerequisite(checksPass = true).copy(prerequisites = _ => Seq(chainedPrerequisite)).build(emptyVatScheme)
+
+        result.status mustBe TLCannotStart
+      }
+    }
+  }
 }

--- a/test/viewmodels/tasklist/VerifyBusinessTaskListSpec.scala
+++ b/test/viewmodels/tasklist/VerifyBusinessTaskListSpec.scala
@@ -45,13 +45,13 @@ class VerifyBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixture 
     "the prerequisites are complete" must {
       "return true" in {
         val scheme = emptyVatScheme.copy(eligibilitySubmissionData = Some(validEligibilitySubmissionData))
-        section.businessInfoRow.prerequisites(scheme).forall(_.isComplete(scheme)) mustBe true
+        section.businessInfoRow.prerequisitesMet(scheme) mustBe true
       }
     }
     "the prerequisites aren't complete" must {
       "return false" in {
         val scheme = emptyVatScheme
-        section.businessInfoRow.prerequisites(scheme).forall(_.isComplete(scheme)) mustBe false
+        section.businessInfoRow.prerequisitesMet(scheme) mustBe false
       }
     }
     "the user is an agent or transactor" must {
@@ -62,7 +62,7 @@ class VerifyBusinessTaskListSpec extends VatRegSpec with VatRegistrationFixture 
           transactorDetails = Some(validTransactorDetails)
         )
 
-        section.businessInfoRow.prerequisites(scheme).forall(_.isComplete(scheme)) mustBe true
+        section.businessInfoRow.prerequisitesMet(scheme) mustBe true
       }
     }
   }


### PR DESCRIPTION
**Bug fix**

Update prerequisite check logic to chain prerequisites from rows, this way any page hop model updates will stop the following sections to be in wrong state (for ex, below screenshot shows page hop to bank details being complete and the next section, **Registration date**, shows as **Not Started** instead of **Cannot Start Yet**)

<img width="528" alt="Screenshot 2022-08-03 at 11 46 27" src="https://user-images.githubusercontent.com/102029646/182592303-5bb4381c-f654-4b54-9614-01f8d7bca2f0.png">

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
