### PR TITLE
SAR-10218 | Fix tax-rep answer pre population

### DIFF
--- a/app/controllers/vatapplication/TaxRepController.scala
+++ b/app/controllers/vatapplication/TaxRepController.scala
@@ -45,7 +45,7 @@ class TaxRepController @Inject()(val authConnector: AuthConnector,
       implicit profile =>
         vatApplicationService.getVatApplication map { vatApplication =>
           vatApplication.hasTaxRepresentative match {
-            case Some(true) => Ok(taxRepPage(TaxRepForm.form.fill(true)))
+            case Some(answer) => Ok(taxRepPage(TaxRepForm.form.fill(answer)))
             case _ => Ok(taxRepPage(TaxRepForm.form))
           }
         }

--- a/it/controllers/vatapplication/TaxRepControllerISpec.scala
+++ b/it/controllers/vatapplication/TaxRepControllerISpec.scala
@@ -5,6 +5,7 @@ package controllers.vatapplication
 import featureswitch.core.config.TaskList
 import itutil.ControllerISpec
 import models.api.vatapplication.VatApplication
+import org.jsoup.Jsoup
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.mvc.Http.HeaderNames
@@ -35,6 +36,9 @@ class TaxRepControllerISpec extends ControllerISpec {
 
       whenReady(buildClient(url).get()) { res =>
         res.status mustBe OK
+        val document = Jsoup.parse(res.body)
+        document.select("input[value=true]").hasAttr("checked") mustBe true
+        document.select("input[value=false]").hasAttr("checked") mustBe false
       }
     }
 
@@ -47,6 +51,9 @@ class TaxRepControllerISpec extends ControllerISpec {
 
       whenReady(buildClient(url).get()) { res =>
         res.status mustBe OK
+        val document = Jsoup.parse(res.body)
+        document.select("input[value=true]").hasAttr("checked") mustBe false
+        document.select("input[value=false]").hasAttr("checked") mustBe true
       }
     }
   }


### PR DESCRIPTION
[SAR-10218](https://jira.tools.tax.service.gov.uk/browse/SAR-10218)

**Bug fix**

Fix pre population of has-tax-representative answer when editing journey, and user has previously selected `false` as initial answer, from summary page.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
