### PR TITLE
SAR-10338 | Restrict roleInTheBusiness check for only certain business entity types

### DIFF
--- a/app/viewmodels/tasklist/AboutYouTaskList.scala
+++ b/app/viewmodels/tasklist/AboutYouTaskList.scala
@@ -62,7 +62,7 @@ class AboutYouTaskList @Inject()(verifyBusinessTaskList: VerifyBusinessTaskList,
       .++ {
         if (isIndividualType(scheme) || isPartnershipWithIndLeadPartner(scheme)) {
           Nil
-        } else if (scheme.partyType.contains(LtdLiabilityPartnership)) {
+        } else if (Seq(Partnership, LtdPartnership, ScotLtdPartnership, ScotPartnership, LtdLiabilityPartnership).exists(scheme.partyType.contains)) {
           Seq(scheme.applicantDetails.exists(_.personalDetails.isDefined))
         } else {
           Seq(

--- a/test/viewmodels/tasklist/AboutYouTaskListSpec.scala
+++ b/test/viewmodels/tasklist/AboutYouTaskListSpec.scala
@@ -294,6 +294,23 @@ class AboutYouTaskListSpec extends VatRegSpec with VatRegistrationFixture with F
         res.status mustBe TLNotStarted
         res.url mustBe controllers.applicant.routes.IndividualIdentificationController.startJourney.url
       }
+      "be not started when personal details is missing but roleInTheBusiness available as Partner" in {
+        val scheme = emptyVatScheme.copy(
+          eligibilitySubmissionData = Some(validEligibilitySubmissionData.copy(
+            partyType = LtdPartnership,
+            isTransactor = false
+          )),
+          applicantDetails = Some(ApplicantDetails(
+            entity = Some(testSoleTrader),
+            personalDetails = None,
+            roleInTheBusiness = testRole
+          )),
+          partners = Some(List(PartnerEntity(testSoleTrader, Partnership, isLeadPartner = true)))
+        )
+        val res = section.personalDetailsRow.build(scheme)
+        res.status mustBe TLNotStarted
+        res.url mustBe controllers.applicant.routes.IndividualIdentificationController.startJourney.url
+      }
     }
     "the user is a Uk Company" when {
       "the UseSoleTraderIdentification feature switch is enabled" must {


### PR DESCRIPTION
[SAR-10338](https://jira.tools.tax.service.gov.uk/browse/SAR-10338)

**Bug fix**

Restrict `roleInTheBusiness` model check for non-partnership entity types when running task completion checks for `PersonalInformation` tasklist row.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
