### PR TITLE
SAR-10339 | Attachments tasklist to treat FRS as optional

### DIFF
--- a/app/viewmodels/tasklist/AttachmentsTaskList.scala
+++ b/app/viewmodels/tasklist/AttachmentsTaskList.scala
@@ -42,7 +42,11 @@ class AttachmentsTaskList @Inject()(vatRegistrationTaskList: VatRegistrationTask
           url = _ => controllers.attachments.routes.AttachmentMethodController.show.url,
           tagId = "attachmentsRequiredRow",
           checks = scheme => checks(scheme, incompleteAttachments),
-          prerequisites = _ => Seq(vatRegistrationTaskList.flatRateSchemeRow)
+          prerequisites = vatScheme => Seq(
+            vatRegistrationTaskList.resolveFlatRateSchemeRow(vatScheme).getOrElse(
+              vatRegistrationTaskList.vatReturnsRow
+            )
+          )
         )
       )
     } else {

--- a/app/viewmodels/tasklist/VatRegistrationTaskList.scala
+++ b/app/viewmodels/tasklist/VatRegistrationTaskList.scala
@@ -127,8 +127,8 @@ class VatRegistrationTaskList @Inject()(aboutTheBusinessTaskList: AboutTheBusine
         resolveBankDetailsRow(vatScheme).map(_.build(vatScheme)),
         resolveVATRegistrationDateRow(vatScheme).map(_.build(vatScheme)),
         Some(vatReturnsRow.build(vatScheme)),
-        resolveFlatRateSchemeRow(vatScheme)
-    ).flatten
+        resolveFlatRateSchemeRow(vatScheme).map(_.build(vatScheme))
+      ).flatten
     )
   }
 
@@ -142,7 +142,7 @@ class VatRegistrationTaskList @Inject()(aboutTheBusinessTaskList: AboutTheBusine
     ) {
       None
     } else {
-      Some(flatRateSchemeRow.build(vatScheme))
+      Some(flatRateSchemeRow)
     }
   }
 

--- a/test/viewmodels/tasklist/VatRegistrationTaskListSpec.scala
+++ b/test/viewmodels/tasklist/VatRegistrationTaskListSpec.scala
@@ -568,7 +568,7 @@ class VatRegistrationTaskListSpec extends VatRegSpec with VatRegistrationFixture
           vatApplication = Some(validVatApplication.copy(turnoverEstimate = Some(BigDecimal(149999)))),
           eligibilitySubmissionData = Some(validEligibilitySubmissionData.copy(registrationReason = ForwardLook))
         )
-        section.resolveFlatRateSchemeRow(scheme).map(_.url) mustBe
+        section.resolveFlatRateSchemeRow(scheme).map(_.build(scheme).url) mustBe
           Some(controllers.flatratescheme.routes.JoinFlatRateSchemeController.show.url)
       }
     }


### PR DESCRIPTION
[SAR-10339](https://jira.tools.tax.service.gov.uk/browse/SAR-10339)

**Bug fix**

For journeys that are not eligible for FRS, attachment tasklist row now uses the previous known state (of vat-returns) as prerequisite.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
