### PR TITLE
SAR-10340 add validation to restrict input value to two decimal points

### DIFF
--- a/app/forms/FlatRateForms.scala
+++ b/app/forms/FlatRateForms.scala
@@ -96,13 +96,15 @@ object FRSStartDateForm {
 
 object EstimateTotalSalesForm {
   implicit val errorCode: ErrorCode = "frs.estimateTotalSales"
-  val regex = """^[0-9 ,]*\.?[0-9]+$""".r
-  val commasNowAllowed = """^[^,]+$""".r
+  val regex = """^[0-9]*\.?[0-9]+$""".r
+  val commasNotAllowed = """^[^,]+$""".r
+  val moreThanTwoDecimalsNotAllowed = """^[0-9]*\.?[0-9]{1,2}$""".r
 
   val form = Form(single("totalSalesEstimate" -> text
     .verifying(StopOnFirstFail(
+      matchesRegex(commasNotAllowed, "validation.estimateTotalSales.commasNotAllowed"),
       regexPattern(regex),
-      matchesRegex(commasNowAllowed, "validation.estimateTotalSales.commasNotAllowed"),
+      matchesRegex(moreThanTwoDecimalsNotAllowed, "validation.estimateTotalSales.moreThanTwoDecimalsNotAllowed"),
       mandatoryFullNumericText))
     .transform[BigDecimal](BigDecimal(_).setScale(2, BigDecimal.RoundingMode.HALF_UP), _.toString)
     .verifying(inRange[BigDecimal](1, BigDecimal("99999999999")))

--- a/app/forms/ReceiveGoodsNipForm.scala
+++ b/app/forms/ReceiveGoodsNipForm.scala
@@ -27,8 +27,9 @@ object ReceiveGoodsNipForm extends RequiredBooleanForm {
   val inputAmount: String = "northernIrelandReceiveGoods"
   implicit val errorCode: ErrorCode = inputAmount
   val yesNo: String = "value"
-  val regex = """^[0-9 ,]*\.?[0-9]+$""".r
-  val commasNowAllowed = """^[^,]+$""".r
+  val regex = """^[0-9]*\.?[0-9]+$""".r
+  val commasNotAllowed = """^[^,]+$""".r
+  val moreThanTwoDecimalsNotAllowed = """^[0-9]*\.?[0-9]{1,2}$""".r
 
   val form = Form(
     tuple(
@@ -36,8 +37,9 @@ object ReceiveGoodsNipForm extends RequiredBooleanForm {
       inputAmount -> mandatoryIf(
         isEqual(yesNo, "true"),
         text.verifying(StopOnFirstFail(
+          matchesRegex(commasNotAllowed, "validation.northernIrelandReceiveGoods.commasNotAllowed"),
           regexPattern(regex),
-          matchesRegex(commasNowAllowed, "validation.northernIrelandReceiveGoods.commasNotAllowed"),
+          matchesRegex(moreThanTwoDecimalsNotAllowed, "validation.northernIrelandReceiveGoods.moreThanTwoDecimalsNotAllowed"),
           mandatoryFullNumericText))
           .transform[BigDecimal](string =>
             BigDecimal(string).setScale(2, BigDecimal.RoundingMode.HALF_UP),

--- a/app/forms/SellOrMoveNipForm.scala
+++ b/app/forms/SellOrMoveNipForm.scala
@@ -27,8 +27,9 @@ object SellOrMoveNipForm extends RequiredBooleanForm {
   val inputAmount: String = "sellOrMoveNip"
   implicit val errorCode: ErrorCode = inputAmount
   val yesNo: String = "value"
-  val regex = """^[0-9 ,]*\.?[0-9]+$""".r
-  val commasNowAllowed = """^[^,]+$""".r
+  val regex = """^[0-9]*\.?[0-9]+$""".r
+  val commasNotAllowed = """^[^,]+$""".r
+  val moreThanTwoDecimalsNotAllowed = """^[0-9]*\.?[0-9]{1,2}$""".r
 
   val form = Form(
     tuple(
@@ -36,8 +37,9 @@ object SellOrMoveNipForm extends RequiredBooleanForm {
       inputAmount -> mandatoryIf(
         isEqual(yesNo, "true"),
         text.verifying(StopOnFirstFail(
+          matchesRegex(commasNotAllowed, "validation.sellOrMoveNip.commasNotAllowed"),
           regexPattern(regex),
-          matchesRegex(commasNowAllowed, "validation.sellOrMoveNip.commasNotAllowed"),
+          matchesRegex(moreThanTwoDecimalsNotAllowed, "validation.sellOrMoveNip.moreThanTwoDecimalsNotAllowed"),
           mandatoryFullNumericText))
           .transform[BigDecimal](s =>
             BigDecimal(s).setScale(2, BigDecimal.RoundingMode.HALF_UP),

--- a/app/forms/TurnoverEstimateForm.scala
+++ b/app/forms/TurnoverEstimateForm.scala
@@ -25,16 +25,18 @@ object TurnoverEstimateForm {
 
   implicit val errorCode: String = "turnoverEstimate"
   val turnoverEstimateKey = "turnoverEstimate"
-  val regex = """^[0-9 ,]*\.?[0-9]+$""".r
-  val commasNowAllowed = """^[^,]+$""".r
+  val regex = """^[0-9]*\.?[0-9]+$""".r
+  val commasNotAllowed = """^[^,]+$""".r
+  val moreThanTwoDecimalsNotAllowed = """^[0-9]*\.?[0-9]{1,2}$""".r
 
   val form: Form[BigDecimal] = Form(
     single(
       turnoverEstimateKey ->
         text
           .verifying(StopOnFirstFail(
+            matchesRegex(commasNotAllowed, "validation.turnoverEstimate.commasNotAllowed"),
             regexPattern(regex),
-            matchesRegex(commasNowAllowed, "validation.turnoverEstimate.commasNotAllowed"),
+            matchesRegex(moreThanTwoDecimalsNotAllowed, "validation.turnoverEstimate.moreThanTwoDecimalsNotAllowed"),
             mandatoryFullNumericText))
           .transform[BigDecimal](string =>
             BigDecimal(string).setScale(2, BigDecimal.RoundingMode.HALF_UP),

--- a/app/forms/ZeroRatedSuppliesForm.scala
+++ b/app/forms/ZeroRatedSuppliesForm.scala
@@ -17,7 +17,6 @@
 package forms
 
 import forms.FormValidation._
-import forms.TurnoverEstimateForm.{commasNowAllowed, regex}
 import play.api.data.Form
 import play.api.data.Forms._
 import uk.gov.hmrc.play.mappers.StopOnFirstFail
@@ -26,16 +25,18 @@ object ZeroRatedSuppliesForm {
 
   implicit val errorCode: String = "zeroRatedSupplies"
   val zeroRatedSuppliesKey = "zeroRatedSupplies"
-  val regex = """^[0-9 ,]*\.?[0-9]+$""".r
-  val commasNowAllowed = """^[^,]+$""".r
+  val regex = """^[0-9]*\.?[0-9]+$""".r
+  val commasNotAllowed = """^[^,]+$""".r
+  val moreThanTwoDecimalsNotAllowed = """^[0-9]*\.?[0-9]{1,2}$""".r
 
   def form(turnoverEstimate: BigDecimal): Form[BigDecimal] = Form(
     single(
       zeroRatedSuppliesKey ->
         text
           .verifying(StopOnFirstFail(
+            matchesRegex(commasNotAllowed, "validation.zeroRatedSupplies.commasNotAllowed"),
             regexPattern(regex),
-            matchesRegex(commasNowAllowed, "validation.zeroRatedSupplies.commasNotAllowed"),
+            matchesRegex(moreThanTwoDecimalsNotAllowed, "validation.zeroRatedSupplies.moreThanTwoDecimalsNotAllowed"),
             mandatoryFullNumericText))
           .transform[BigDecimal](string =>
             BigDecimal(string).setScale(2, BigDecimal.RoundingMode.HALF_UP),

--- a/app/models/FlatRateModel.scala
+++ b/app/models/FlatRateModel.scala
@@ -62,7 +62,7 @@ object FlatRateScheme {
       JsSuccess(FlatRateScheme(
         Some(joinFrs),
         if (!joinFrs && details.isEmpty) None else Some(businessGoods.isDefined),
-        businessGoods.map(js => (js \ "estimatedTotalSales").as[Long]),
+        businessGoods.map(js => (js \ "estimatedTotalSales").as[BigDecimal]),
         businessGoods.map(js => (js \ "overTurnover").as[Boolean]),
         if (details.isEmpty) None else Some(joinFrs),
         start,

--- a/conf/messages
+++ b/conf/messages
@@ -485,6 +485,7 @@ pages.turnoverEstimate.hint                                 = For example, £600
 validation.turnoverEstimate.missing                         = Enter the VAT-taxable turnover expected for the next 12 months
 validation.turnoverEstimate.invalid                         = Enter the VAT-taxable turnover, expected for the next 12 months, in the correct format
 validation.turnoverEstimate.commasNotAllowed                = The VAT-taxable turnover, expected for the next 12 months, amount cannot include commas
+validation.turnoverEstimate.moreThanTwoDecimalsNotAllowed   = The VAT-taxable turnover, expected for the next 12 months, can only include pounds and pence
 validation.turnoverEstimate.range.above                     = Give an estimate that is more than or equal to £{0}
 validation.turnoverEstimate.range.below                     = Give an estimate that is less than or equal to £{0}
 
@@ -499,6 +500,7 @@ pages.zeroRatedSupplies.hint                                = For example, £600
 validation.zeroRatedSupplies.missing                        = Enter the value you expect the business’s zero-rated taxable goods to be over the next 12 months
 validation.zeroRatedSupplies.invalid                        = Enter the value of zero-rated taxable goods, expected over the next 12 months, in the correct format
 validation.zeroRatedSupplies.commasNotAllowed               = The value of zero-rated taxable goods, expected over the next 12 months, cannot include commas
+validation.zeroRatedSupplies.moreThanTwoDecimalsNotAllowed  = The value of zero-rated taxable goods, expected over the next 12 months, can only include pounds and pence
 validation.zeroRatedSupplies.range.above                    = The value of taxable turnover that is zero-rated must be less than or equal to the total value of the taxable turnover
 validation.zeroRatedSupplies.range.below                    = Do not use negative numbers like -1200
 
@@ -943,6 +945,7 @@ validation.frs.estimateTotalSales.range.below = Enter an estimate which is £1 o
 validation.frs.estimateTotalSales.missing     = Enter the business’s estimated total sales, including VAT, for the next 3 months
 validation.frs.estimateTotalSales.invalid     = Enter the business’s estimated total sales, including VAT, for the next 3 months, in the correct format
 validation.estimateTotalSales.commasNotAllowed= The business’s estimated total sales, including VAT, for the next 3 months, cannot include commas
+validation.estimateTotalSales.moreThanTwoDecimalsNotAllowed   = The business’s estimated total sales, including VAT, for the next 3 months, can only include pounds and pence
 
 ## FRS Confirm business sector Page
 pages.frs.confirmBusinessSector.heading                   = Confirm the business type for the Flat Rate Scheme
@@ -1302,6 +1305,7 @@ nip.receiveGoods.missing                                 = Select yes if the bus
 validation.northernIrelandReceiveGoods.missing           = Enter the estimated value of the goods
 validation.northernIrelandReceiveGoods.invalid           = Enter the estimated value of the goods in the correct format
 validation.northernIrelandReceiveGoods.commasNotAllowed  = The estimated value of the goods cannot include commas
+validation.northernIrelandReceiveGoods.moreThanTwoDecimalsNotAllowed = The estimated value of the goods can only include pounds and pence
 
 # NORTHERN IRELAND PROTOCOL
 
@@ -1315,7 +1319,7 @@ nip.error.missing                                        = Select yes if the bus
 validation.sellOrMoveNip.missing                         = Enter the estimated value of the goods
 validation.sellOrMoveNip.invalid                         = Enter the estimated value of the goods in the correct format
 validation.sellOrMoveNip.commasNotAllowed                = The estimated value of the goods cannot include commas
-
+validation.sellOrMoveNip.moreThanTwoDecimalsNotAllowed   = The estimated value of the goods can only include pounds and pence
 
 pages.EmailDocuments.heading                             = We need you to send the documents to the following HMRC email address
 pages.EmailDocuments.para1                               = For us to be able to progress your VAT registration quickly we need you to send these documents as soon as you have submitted the application form.

--- a/it/controllers/vatapplication/TurnoverEstimateControllerISpec.scala
+++ b/it/controllers/vatapplication/TurnoverEstimateControllerISpec.scala
@@ -73,7 +73,7 @@ class TurnoverEstimateControllerISpec extends ControllerISpec {
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
       val res: Future[WSResponse] = buildClient(url).post(Json.obj(
-        "turnoverEstimate" -> "10000.535"
+        "turnoverEstimate" -> "10000.53"
       ))
 
       whenReady(res) { result =>

--- a/it/controllers/vatapplication/ZeroRatedSuppliesControllerISpec.scala
+++ b/it/controllers/vatapplication/ZeroRatedSuppliesControllerISpec.scala
@@ -83,7 +83,7 @@ class ZeroRatedSuppliesControllerISpec extends ControllerISpec {
       insertCurrentProfileIntoDb(currentProfile, sessionId)
 
       val res: Future[WSResponse] = buildClient(url).post(Json.obj(
-        "zeroRatedSupplies" -> "10000.535"
+        "zeroRatedSupplies" -> "10000.53"
       ))
 
       whenReady(res) { result =>

--- a/test/forms/ReceiveGoodsNipFormSpec.scala
+++ b/test/forms/ReceiveGoodsNipFormSpec.scala
@@ -28,6 +28,7 @@ class ReceiveGoodsNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val validYesNo: String = "true"
   val testNonNumberReceiveGoodsNip: String = "test"
   val testReceiveGoodsNipWithComma: String = "14,999.99"
+  val testReceiveGoodsNipWithMoreDecimals: String = "14999.999"
   val testInvalidReceiveGoodsNip: String = (999999999999999L + 1).toString
   val testNegativeReceiveGoodsNip: String = "-1"
 
@@ -35,6 +36,7 @@ class ReceiveGoodsNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val missing_receive_goods_nip_nip_error_key: String = "validation.northernIrelandReceiveGoods.missing"
   val missing_yes_no_error_key: String = "nip.receiveGoods.missing"
   val commasNotAllowed_receive_goods_nip_error_key: String = "validation.northernIrelandReceiveGoods.commasNotAllowed"
+  val moreThanTwoDecimalsNotAllowed_receive_goods_nip_error_key = "validation.northernIrelandReceiveGoods.moreThanTwoDecimalsNotAllowed"
   val too_big_receive_goods_nip_nip_error_key: String = "validation.northernIrelandReceiveGoods.range.above"
   val negative_receive_goods_nip_nip_error_key: String = "validation.northernIrelandReceiveGoods.range.below"
 
@@ -71,6 +73,14 @@ class ReceiveGoodsNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
       form.errors.size mustBe 1
       form.errors.head.key mustBe ReceiveGoodsNipForm.inputAmount
       form.errors.head.message mustBe commasNotAllowed_receive_goods_nip_error_key
+    }
+
+    "validate that receiveGoodsNip with more than two decimals fails" in {
+      val form = receiveGoodsNipForm.bind(Map(ReceiveGoodsNipForm.yesNo -> validYesNo, ReceiveGoodsNipForm.inputAmount -> testReceiveGoodsNipWithMoreDecimals))
+
+      form.errors.size mustBe 1
+      form.errors.head.key mustBe ReceiveGoodsNipForm.inputAmount
+      form.errors.head.message mustBe moreThanTwoDecimalsNotAllowed_receive_goods_nip_error_key
     }
 
     "validate that when receiveGoodsNip is negative the form fails" in {

--- a/test/forms/SellOrMoveNipFormSpec.scala
+++ b/test/forms/SellOrMoveNipFormSpec.scala
@@ -28,6 +28,7 @@ class SellOrMoveNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val validYesNo: String = "true"
   val testNonNumberSellOrMoveNip: String = "test"
   val testSellOrMoveNipWithComma: String = "14,999.99"
+  val testSellOrMoveNipWithMoreDecimals: String = "14999.999"
   val testInvalidSellOrMoveNip: String = (999999999999999L + 1).toString
   val testNegativeSellOrMoveNip: String = "-1"
 
@@ -35,6 +36,7 @@ class SellOrMoveNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val missing_sell_or_move_nip_error_key: String = "validation.sellOrMoveNip.missing"
   val missing_yes_no_error_key: String = "nip.error.missing"
   val commasNotAllowed_sell_or_move_nip_error_key: String = "validation.sellOrMoveNip.commasNotAllowed"
+  val moreThanTwoDecimalsNotAllowed_sell_or_move_nip_error_key = "validation.sellOrMoveNip.moreThanTwoDecimalsNotAllowed"
   val too_big_sell_or_move_nip_error_key: String = "validation.sellOrMoveNip.range.above"
   val negative_sell_or_move_nip_error_key: String = "validation.sellOrMoveNip.range.below"
 
@@ -71,6 +73,14 @@ class SellOrMoveNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
       form.errors.size mustBe 1
       form.errors.head.key mustBe SellOrMoveNipForm.inputAmount
       form.errors.head.message mustBe commasNotAllowed_sell_or_move_nip_error_key
+    }
+
+    "validate that sellOrMoveNip with more than two decimals fails" in {
+      val form = sellOrMoveNipForm.bind(Map(SellOrMoveNipForm.yesNo -> validYesNo, SellOrMoveNipForm.inputAmount -> testSellOrMoveNipWithMoreDecimals))
+
+      form.errors.size mustBe 1
+      form.errors.head.key mustBe SellOrMoveNipForm.inputAmount
+      form.errors.head.message mustBe moreThanTwoDecimalsNotAllowed_sell_or_move_nip_error_key
     }
 
     "validate that when sellOrMoveNip is negative the form fails" in {

--- a/test/forms/TurnoverEstimateFormSpec.scala
+++ b/test/forms/TurnoverEstimateFormSpec.scala
@@ -27,12 +27,14 @@ class TurnoverEstimateFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val validTurnoverEstimate: BigDecimal = 14999.99
   val testNonNumberTurnoverEstimate: String = "test"
   val testTurnoverEstimateWithComma: String = "14,999.99"
+  val testTurnoverEstimateWithMoreDecimals: String = "14999.999"
   val testInvalidTurnoverEstimate: String = (999999999999999L + 1).toString
   val testNegativeTurnoverEstimate: String = "-1"
 
   val invalid_turnover_estimate_error_key: String = "validation.turnoverEstimate.invalid"
   val missing_turnover_estimate_error_key: String = "validation.turnoverEstimate.missing"
   val commasNotAllowed_turnover_estimate_error_key: String = "validation.turnoverEstimate.commasNotAllowed"
+  val moreThanTwoDecimalsNotAllowed_turnover_estimate_error_key: String = "validation.turnoverEstimate.moreThanTwoDecimalsNotAllowed"
   val too_big_turnover_estimate_error_key: String = "validation.turnoverEstimate.range.above"
   val negative_turnover_estimate_error_key: String = "validation.turnoverEstimate.range.below"
 
@@ -63,6 +65,14 @@ class TurnoverEstimateFormSpec extends PlaySpec with GuiceOneAppPerSuite {
       form.errors.size mustBe 1
       form.errors.head.key mustBe TurnoverEstimateForm.turnoverEstimateKey
       form.errors.head.message mustBe commasNotAllowed_turnover_estimate_error_key
+    }
+
+    "validate that turnoverEstimate with more than two decimals fails" in {
+      val form = turnoverEstimateForm.bind(Map(TurnoverEstimateForm.turnoverEstimateKey -> testTurnoverEstimateWithMoreDecimals))
+
+      form.errors.size mustBe 1
+      form.errors.head.key mustBe TurnoverEstimateForm.turnoverEstimateKey
+      form.errors.head.message mustBe moreThanTwoDecimalsNotAllowed_turnover_estimate_error_key
     }
 
     "validate that when turnoverEstimate > 999999999999999 the form fails" in {

--- a/test/forms/ZeroRatedSuppliesFormSpec.scala
+++ b/test/forms/ZeroRatedSuppliesFormSpec.scala
@@ -28,12 +28,14 @@ class ZeroRatedSuppliesFormSpec extends PlaySpec with GuiceOneAppPerSuite {
   val validZeroRatedSupplies: BigDecimal = 14999.99
   val testNonNumberZeroRatedSupplies: String = "test"
   val testZeroRatedSuppliesWithComma: String = "14,999.99"
+  val testZeroRatedSuppliesWithMoreDecimals: String = "14999.999"
   val testInvalidZeroRatedSupplies: String = "16000"
   val testNegativeZeroRatedSupplies: String = "-1"
 
   val invalid_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.invalid"
   val missing_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.missing"
   val commasNotAllowed_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.commasNotAllowed"
+  val moreThanTwoDecimalsNotAllowed_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.moreThanTwoDecimalsNotAllowed"
   val too_big_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.range.above"
   val negative_zero_rated_supplies_error_key: String = "validation.zeroRatedSupplies.range.below"
 
@@ -64,6 +66,14 @@ class ZeroRatedSuppliesFormSpec extends PlaySpec with GuiceOneAppPerSuite {
       form.errors.size mustBe 1
       form.errors.head.key mustBe ZeroRatedSuppliesForm.zeroRatedSuppliesKey
       form.errors.head.message mustBe commasNotAllowed_zero_rated_supplies_error_key
+    }
+
+    "validate zeroRatedSupplies with more than two decimals fails" in {
+      val form = zeroRatedSuppliesForm.bind(Map(ZeroRatedSuppliesForm.zeroRatedSuppliesKey -> testZeroRatedSuppliesWithMoreDecimals))
+
+      form.errors.size mustBe 1
+      form.errors.head.key mustBe ZeroRatedSuppliesForm.zeroRatedSuppliesKey
+      form.errors.head.message mustBe moreThanTwoDecimalsNotAllowed_zero_rated_supplies_error_key
     }
 
     "validate that when zeroRatedSupplies > turnoverEstimates the form fails" in {


### PR DESCRIPTION
SAR-10340 add validation to restrict input value to two decimal points for turnover, zero rated turnover, NIP

**New feature**

## Checklist

* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
