### PR TITLE
SAR-10498 | Add missing legend to fieldset on FormerName page

### DIFF
--- a/app/views/applicant/FormerName.scala.html
+++ b/app/views/applicant/FormerName.scala.html
@@ -45,9 +45,10 @@
 
     @formWithCSRF(action = applicantRoutes.FormerNameController.submit) {
         @yesNoRadio(
-        form = formerNameForm,
-        headingKey = "",
-        isPageHeading = false
+            form = formerNameForm,
+            headingKey = name.fold(messages("pages.formerName.yourHeading"))(name => messages("pages.formerName.namedHeading", name)),
+            isPageHeading = false,
+            classes = "govuk-visually-hidden",
         )
 
         @button(messages("app.common.continue"))

--- a/test/views/applicant/FormerNameViewSpec.scala
+++ b/test/views/applicant/FormerNameViewSpec.scala
@@ -46,8 +46,16 @@ class FormerNameViewSpec extends VatRegViewSpec {
       nonTransactorDoc.heading mustBe Some(heading)
     }
 
+    "have the correct legend for non transactor flow" in {
+      nonTransactorDoc.select(Selectors.legend(1)).text() mustBe heading
+    }
+
     "have the correct heading when the user is a transactor" in {
       transactorDoc.select(Selectors.h1).text mustBe namedHeading
+    }
+
+    "have the correct legend for transactor flow" in {
+      transactorDoc.select(Selectors.legend(1)).text() mustBe namedHeading
     }
 
     "have the correct page title" in new ViewSetup {


### PR DESCRIPTION
[SAR-10498](https://jira.tools.tax.service.gov.uk/browse/SAR-10498)

**Bug fix**

As identified in accessibility report, add the missing legend to fieldset on former name page

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
