### PR TITLE
SAR-10720 | Add missing hint texts to partner entity pages

### DIFF
--- a/app/views/applicant/BusinessPartnerEntityType.scala.html
+++ b/app/views/applicant/BusinessPartnerEntityType.scala.html
@@ -86,7 +86,8 @@
                         checked = form("value").value.contains(PartyType.stati(ScotPartnership))
                     )
                 ),
-                legendAsHeading = true
+                legendAsHeading = true,
+                subHeading = Some(messages("pages.businessLeadPartnerEntityType.subHeading"))
             )
 
             @button("app.common.continue")

--- a/app/views/applicant/PartnerEntityType.scala.html
+++ b/app/views/applicant/PartnerEntityType.scala.html
@@ -28,7 +28,8 @@
         button: button,
         formWithCSRF: FormWithCSRF,
         errorSummary: errorSummary,
-        inputRadio: inputRadio
+        inputRadio: inputRadio,
+        panelIndent: components.panelIndent
 )
 
 @(form: Form[PartyType], isTransactor: Boolean, index: Int)(implicit request: Request[_], messages: Messages, appConfig: FrontendAppConfig)
@@ -47,6 +48,12 @@
 
         @errorSummary(form.errors)
 
+        @h1(headingMessage)
+
+        @panelIndent {
+            @messages("pages.partnerEntityType.indentText")
+        }
+
         @formWithCSRF(
             action = if (index == leadEntityIndex) {
                 controllers.applicant.routes.LeadPartnerEntityController.submitLeadPartnerEntity
@@ -56,7 +63,7 @@
         ) {
             @inputRadio(
                 form = form,
-                legend = headingMessage,
+                legend = "",
                 items = Seq(
                     RadioItem(
                         content = Text(messages("pages.leadPartnerEntityType.soleTrader")),
@@ -69,7 +76,7 @@
                         checked = form("value").value.contains(PartyType.stati(BusinessEntity))
                     )
                 ),
-                legendAsHeading = true
+                legendAsHeading = false
             )
 
             @button("app.common.continue")

--- a/conf/messages
+++ b/conf/messages
@@ -1175,8 +1175,10 @@ pages.leadPartnerEntityType.missing                      = Select the type of pa
 pages.leadPartnerEntityType.missing.3pt                  = Select the type of lead partner
 pages.partnerEntityType.missing                          = Select the partner type
 pages.partnerEntityType.heading                          = What type of partner is the {0} partner?
+pages.partnerEntityType.indentText                       = A partner in a partnership does not have to be an actual person. For example, a limited company can be a partner.
 
 # BUSINESS LEAD PARTNER ENTITY TYPE
+pages.businessLeadPartnerEntityType.subHeading           = Partner details
 pages.businessLeadPartnerEntityType.heading              = What type of business are you within the partnership?
 pages.businessLeadPartnerEntityType.heading.3pt          = What type of business is the lead partner within the partnership?
 pages.businessLeadPartnerEntityType.netp                 = Non-established taxable person (NETP)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1175,8 +1175,11 @@ pages.leadPartnerEntityType.missing                      = Select the type of pa
 pages.leadPartnerEntityType.missing.3pt                  = Select the type of lead partner
 pages.partnerEntityType.heading                          = What type of partner is the {0} partner?
 pages.partnerEntityType.missing                          = Select the partner type
+pages.partnerEntityType.indentText                       = A partner in a partnership does not have to be an actual person. For example, a limited company can be a partner.
+
 
 # BUSINESS LEAD PARTNER ENTITY TYPE
+pages.businessLeadPartnerEntityType.subHeading           = Partner arweiniol
 pages.businessLeadPartnerEntityType.heading              = What type of business are you within the partnership?
 pages.businessLeadPartnerEntityType.heading.3pt          = What type of business is the lead partner within the partnership?
 pages.businessLeadPartnerEntityType.netp                 = Person trethadwy sydd heb ei sefydlu (NETP)

--- a/test/views/BaseSelectors.scala
+++ b/test/views/BaseSelectors.scala
@@ -39,6 +39,7 @@ trait BaseSelectors {
   val detailsSummary = ".govuk-details__summary-text"
   val detailsContent = ".govuk-details__text"
   val hidden = ".hidden"
+  val subHeading = ".govuk-caption-xl"
   val orderedList: Int => String = i => s"main ol.govuk-list.govuk-list--number li:nth-of-type($i)"
   def radio(n: Int) = s"div.govuk-radios__item:nth-of-type($n) label"
 

--- a/test/views/BaseSelectors.scala
+++ b/test/views/BaseSelectors.scala
@@ -39,7 +39,6 @@ trait BaseSelectors {
   val detailsSummary = ".govuk-details__summary-text"
   val detailsContent = ".govuk-details__text"
   val hidden = ".hidden"
-  val subHeading = ".govuk-caption-xl"
   val orderedList: Int => String = i => s"main ol.govuk-list.govuk-list--number li:nth-of-type($i)"
   def radio(n: Int) = s"div.govuk-radios__item:nth-of-type($n) label"
 

--- a/test/views/applicant/BusinessPartnerEntityTypeViewSpec.scala
+++ b/test/views/applicant/BusinessPartnerEntityTypeViewSpec.scala
@@ -41,13 +41,16 @@ class BusinessPartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitc
 
   object LeadBusinessPartnerEntityExpectedContent {
     val heading: String = "What type of business are you within the partnership?"
+    val withSubHeading: String = s"$heading This section is Partner details"
     val heading3pt: String = "What type of business is the lead partner within the partnership?"
+    val withSubHeading3pt: String = s"$heading3pt This section is Partner details"
     val title = s"$heading - Register for VAT - GOV.UK"
     val error: String = "Select the type of business the lead partner is within the partnership"
   }
 
   object AdditionalBusinessPartnerEntityExpectedContent {
     val heading: String = s"What type of business is the second partner within the partnership?"
+    val withSubHeading: String = s"$heading This section is Partner details"
     val title: String = s"$heading - Register for VAT - GOV.UK"
     val error: String = "Select the type of partner you are"
   }
@@ -66,7 +69,7 @@ class BusinessPartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitc
     }
 
     "have the correct heading" in new ViewSetup() {
-      doc.heading mustBe Some(LeadBusinessPartnerEntityExpectedContent.heading)
+      doc.heading must contain (LeadBusinessPartnerEntityExpectedContent.withSubHeading)
     }
 
     "have the correct button1" in new ViewSetup() {
@@ -103,7 +106,7 @@ class BusinessPartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitc
 
     "3rd party flow has correct heading" in new ViewSetup() {
       val doc3pt: Document = Jsoup.parse(view(PartnerForm.form, isTransactor = true, leadEntityIndex).body)
-      doc3pt.heading mustBe Some(LeadBusinessPartnerEntityExpectedContent.heading3pt)
+      doc3pt.heading mustBe Some(LeadBusinessPartnerEntityExpectedContent.withSubHeading3pt)
     }
   }
 
@@ -122,7 +125,7 @@ class BusinessPartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitc
     }
 
     "have the correct heading" in new ViewSetup() {
-      doc.heading mustBe Some(AdditionalBusinessPartnerEntityExpectedContent.heading)
+      doc.heading mustBe Some(AdditionalBusinessPartnerEntityExpectedContent.withSubHeading)
     }
 
     "have the correct button1" in new ViewSetup() {

--- a/test/views/applicant/BusinessPartnerEntityTypeViewSpec.scala
+++ b/test/views/applicant/BusinessPartnerEntityTypeViewSpec.scala
@@ -69,7 +69,7 @@ class BusinessPartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitc
     }
 
     "have the correct heading" in new ViewSetup() {
-      doc.heading must contain (LeadBusinessPartnerEntityExpectedContent.withSubHeading)
+      doc.heading mustBe Some(LeadBusinessPartnerEntityExpectedContent.withSubHeading)
     }
 
     "have the correct button1" in new ViewSetup() {

--- a/test/views/applicant/PartnerEntityTypeViewSpec.scala
+++ b/test/views/applicant/PartnerEntityTypeViewSpec.scala
@@ -33,6 +33,7 @@ class PartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitching {
     val button2: String = "A business"
     val continue: String = "Save and continue"
     val continueLater: String = "Save and come back later"
+    val panelText: String = "A partner in a partnership does not have to be an actual person. For example, a limited company can be a partner."
   }
   object LeadPartnerExpectedContent {
     val heading: String = "What type of partner are you?"
@@ -70,6 +71,10 @@ class PartnerEntityTypeViewSpec extends VatRegViewSpec with FeatureSwitching {
 
     "have the correct button2" in new ViewSetup() {
       doc.radio("BusinessEntity") mustBe Some(GlobalExpectedContent.button2)
+    }
+
+    "have the correct panel text" in new ViewSetup {
+      doc.select(Selectors.indent).text mustBe GlobalExpectedContent.panelText
     }
 
     "have the correct continue button" in new ViewSetup() {


### PR DESCRIPTION
[SAR-10720](https://jira.tools.tax.service.gov.uk/browse/SAR-10720)

**Bug fix**

Added hint text to partner entity selection and business entity pages.

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
