### PR TITLE
Reduce number of compiler warnings

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -20,6 +20,7 @@ import controllers.callbacks.routes
 import featureswitch.core.config._
 import models.api._
 import play.api.Configuration
+import uk.gov.hmrc.http.InternalServerException
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.nio.charset.Charset
@@ -223,6 +224,7 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, runModeCon
         case ScotPartnership => "scottish-partnership-journey"
         case ScotLtdPartnership => "scottish-limited-partnership-journey"
         case LtdLiabilityPartnership => "limited-liability-partnership-journey"
+        case _ => throw new InternalServerException(s"Party type $partyType is not a valid partnership party type")
       }
       s"$partnershipIdHost/partnership-identification/api/$url"
     }

--- a/app/config/frontendWiring.scala
+++ b/app/config/frontendWiring.scala
@@ -18,7 +18,7 @@ package config
 
 import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.hmrc.auth.core.PlayAuthConnector
-import uk.gov.hmrc.crypto.{ApplicationCrypto, CryptoWithKeysFromConfig}
+import uk.gov.hmrc.crypto.ApplicationCrypto
 import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.http.cache.client.{SessionCache, ShortLivedCache, ShortLivedHttpCaching}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -44,7 +44,7 @@ class VatShortLivedHttpCaching @Inject()(val http: HttpClient, config: ServicesC
 class VatShortLivedCache @Inject()(val shortLiveCache: ShortLivedHttpCaching,
                                    applicationCrypto: ApplicationCrypto) extends ShortLivedCache {
 
-  override implicit lazy val crypto: CryptoWithKeysFromConfig = applicationCrypto.JsonCrypto
+  override implicit lazy val crypto = applicationCrypto.JsonCrypto
 
 }
 

--- a/app/connectors/ICLConnector.scala
+++ b/app/connectors/ICLConnector.scala
@@ -16,12 +16,11 @@
 
 package connectors
 
+import javax.inject.{Inject, Singleton}
 import play.api.libs.json.JsObject
-import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/connectors/IncorpIdConnector.scala
+++ b/app/connectors/IncorpIdConnector.scala
@@ -22,7 +22,7 @@ import models.external.IncorporatedEntity
 import models.external.incorporatedentityid.IncorpIdJourneyConfig
 import play.api.http.Status.CREATED
 import play.api.libs.json.{JsError, JsSuccess, JsValue}
-import uk.gov.hmrc.http.HttpReads.Implicits.{readFromJson, readRaw}
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, InternalServerException}
 
 import javax.inject.{Inject, Singleton}
@@ -36,6 +36,7 @@ class IncorpIdConnector @Inject()(httpClient: HttpClient, config: FrontendAppCon
       case UkCompany => config.startUkCompanyIncorpJourneyUrl()
       case RegSociety => config.startRegSocietyIncorpIdJourneyUrl()
       case CharitableOrg => config.startCharitableOrgIncorpIdJourneyUrl()
+      case _ => throw new InternalServerException(s"Party type $partyType is not a valid incorporated entity party type")
     }
 
     httpClient.POST(url, journeyConfig).map {

--- a/app/connectors/MinorEntityIdConnector.scala
+++ b/app/connectors/MinorEntityIdConnector.scala
@@ -37,6 +37,7 @@ class MinorEntityIdConnector @Inject()(httpClient: HttpClient, config: FrontendA
       case UnincorpAssoc => config.startUnincorpAssocJourneyUrl
       case Trust => config.startTrustJourneyUrl
       case NonUkNonEstablished => config.startNonUKCompanyJourneyUrl
+      case _ => throw new InternalServerException(s"Party type $partyType is not a valid minor entity party type")
     }
 
     httpClient.POST(url, journeyConfig).map {

--- a/app/connectors/RegistrationApiConnector.scala
+++ b/app/connectors/RegistrationApiConnector.scala
@@ -73,8 +73,7 @@ class RegistrationApiConnector @Inject()(val http: HttpClient,
     http.PUT[T, T](url, section)
   }
 
-  def deleteSection[T: ApiKey](regId: String, idx: Option[Int] = None)(implicit hc: HeaderCarrier, format: Format[T]): Future[Boolean] = {
-
+  def deleteSection[T: ApiKey](regId: String, idx: Option[Int] = None)(implicit hc: HeaderCarrier): Future[Boolean] = {
     val url = appendIndexToUrl(s"${config.backendHost}/vatreg/registrations/$regId/sections/${ApiKey[T]}", idx)
 
     http.DELETE[HttpResponse](url).map {

--- a/app/connectors/SoleTraderIdentificationConnector.scala
+++ b/app/connectors/SoleTraderIdentificationConnector.scala
@@ -59,8 +59,8 @@ class SoleTraderIdentificationConnector @Inject()(val httpClient: HttpClient, ap
             response.json.validate[SoleTraderIdEntity](SoleTraderIdEntity.apiFormat)) match {
             case (JsSuccess(transactorDetails, _), JsSuccess(optSoleTrader, _)) =>
               (transactorDetails, optSoleTrader)
-            case (JsError(errors), _) =>
-              throw new InternalServerException(s"Sole trader ID returned invalid JSON ${errors.map(_._1).mkString(", ")}")
+            case (jsError@JsError(_), _) =>
+              throw new InternalServerException(s"Sole trader ID returned invalid JSON ${jsError.errors.map(_._1).mkString(", ")}")
           }
         case status =>
           throw new InternalServerException(s"[SoleTraderIdentificationConnector] Unexpected status returned from STI when retrieving sole trader details: $status")

--- a/app/connectors/TrafficManagementConnector.scala
+++ b/app/connectors/TrafficManagementConnector.scala
@@ -19,7 +19,6 @@ package connectors
 import config.FrontendAppConfig
 import models.api.trafficmanagement.{ClearTrafficManagementError, ClearTrafficManagementResponse, RegistrationInformation, TrafficManagementCleared}
 import play.api.http.Status._
-import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
 import javax.inject.{Inject, Singleton}

--- a/app/connectors/UpscanConnector.scala
+++ b/app/connectors/UpscanConnector.scala
@@ -41,7 +41,6 @@ class UpscanConnector @Inject()(httpClient: HttpClient, appConfig: FrontendAppCo
 
     httpClient.POST[JsValue, HttpResponse](url, body).map {
       case response@HttpResponse(OK, _, _) => response.json.as[UpscanResponse]
-
       case response => throw new InternalServerException(s"[UpscanConnector] Upscan initiate received an unexpected response Status: ${response.status}")
     }
   }

--- a/app/connectors/VatRegistrationConnector.scala
+++ b/app/connectors/VatRegistrationConnector.scala
@@ -39,7 +39,7 @@ class VatRegistrationConnector @Inject()(val http: HttpClient,
     }
   }
 
-  def getAllRegistrations(implicit hc: HeaderCarrier, rds: HttpReads[VatSchemeHeader]): Future[List[VatSchemeHeader]] =
+  def getAllRegistrations(implicit hc: HeaderCarrier): Future[List[VatSchemeHeader]] =
     http.GET[List[JsValue]](s"$vatRegUrl/vatreg/registrations").recover {
       case e => throw logResponse(e, "getRegistration")
     }.map { list =>

--- a/app/controllers/ApplicationProgressSavedController.scala
+++ b/app/controllers/ApplicationProgressSavedController.scala
@@ -36,7 +36,7 @@ class ApplicationProgressSavedController @Inject()(val vatApplicationService: Va
 
   def show: Action[AnyContent] = isAuthenticatedWithProfile() {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(applicationProgressSavedView()))
   }
 

--- a/app/controllers/SaveAndRetrieveController.scala
+++ b/app/controllers/SaveAndRetrieveController.scala
@@ -31,7 +31,7 @@ class SaveAndRetrieveController @Inject()(val authConnector: AuthConnector,
                                           bcc: BaseControllerComponents,
                                           appConfig: FrontendAppConfig) extends BaseController {
 
-  def save: Action[AnyContent] = isAuthenticatedWithProfile() { implicit request => implicit profile =>
+  def save: Action[AnyContent] = isAuthenticatedWithProfile() { _ => _ =>
     Future.successful(Redirect(controllers.routes.ApplicationProgressSavedController.show.url))
   }
 

--- a/app/controllers/SubmissionInProgressController.scala
+++ b/app/controllers/SubmissionInProgressController.scala
@@ -37,9 +37,8 @@ class SubmissionInProgressController @Inject()(view: SubmissionInProgress,
   extends BaseController with SessionProfile {
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
-    implicit request =>
-      implicit profile =>
-        Future.successful(Ok(view()))
+    implicit request =>_ =>
+      Future.successful(Ok(view()))
   }
 
   val submit: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {

--- a/app/controllers/attachments/DocumentsRequiredController.scala
+++ b/app/controllers/attachments/DocumentsRequiredController.scala
@@ -68,7 +68,7 @@ class DocumentsRequiredController @Inject()(val authConnector: AuthClientConnect
   }
 
   val submit: Action[AnyContent] = isAuthenticatedWithProfile() {
-    implicit request => implicit profile =>
+    _ => _ =>
       Future.successful(Redirect(routes.AttachmentMethodController.show))
   }
 

--- a/app/controllers/attachments/EmailDocumentsController.scala
+++ b/app/controllers/attachments/EmailDocumentsController.scala
@@ -35,7 +35,7 @@ class EmailDocumentsController @Inject()(view: EmailDocuments,
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
     implicit request =>
-      implicit profile =>
+      _ =>
           Future.successful(Ok(view()))
   }
 

--- a/app/controllers/attachments/Vat1TRRequiredController.scala
+++ b/app/controllers/attachments/Vat1TRRequiredController.scala
@@ -36,7 +36,7 @@ class Vat1TRRequiredController @Inject()(view: Vat1TRRequired,
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 

--- a/app/controllers/attachments/Vat2RequiredController.scala
+++ b/app/controllers/attachments/Vat2RequiredController.scala
@@ -36,7 +36,7 @@ class Vat2RequiredController @Inject()(view: Vat2Required,
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 

--- a/app/controllers/attachments/Vat51RequiredController.scala
+++ b/app/controllers/attachments/Vat51RequiredController.scala
@@ -36,7 +36,7 @@ class Vat51RequiredController @Inject()(view: Vat51Required,
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 

--- a/app/controllers/attachments/Vat5LRequiredController.scala
+++ b/app/controllers/attachments/Vat5LRequiredController.scala
@@ -36,7 +36,7 @@ class Vat5LRequiredController @Inject()(view: Vat5LRequired,
 
   val show: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 

--- a/app/controllers/errors/EmailPasscodeNotFoundController.scala
+++ b/app/controllers/errors/EmailPasscodeNotFoundController.scala
@@ -35,8 +35,7 @@ class EmailPasscodeNotFoundController @Inject()(view: passcode_not_found,
   extends BaseController with SessionProfile {
 
   def show(redirectUrl: String): Action[AnyContent] = isAuthenticatedWithProfile() {
-    implicit request =>
-      implicit profile =>
-        Future.successful(Ok(view(redirectUrl)))
+    implicit request =>_ =>
+      Future.successful(Ok(view(redirectUrl)))
   }
 }

--- a/app/controllers/errors/EmailPasscodesMaxAttemptsExceededController.scala
+++ b/app/controllers/errors/EmailPasscodesMaxAttemptsExceededController.scala
@@ -36,7 +36,7 @@ class EmailPasscodesMaxAttemptsExceededController @Inject()(view: maxPasscodeAtt
 
   def show: Action[AnyContent] = isAuthenticatedWithProfile() {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 }

--- a/app/controllers/errors/ErrorController.scala
+++ b/app/controllers/errors/ErrorController.scala
@@ -50,7 +50,7 @@ class ErrorController @Inject()(val authConnector: AuthClientConnector,
   }
 
   def alreadySubmittedSignOut: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {
-    implicit request => _ => Future.successful(Redirect(controllers.callbacks.routes.SignInOutController.signOut))
+    _ => _ => Future.successful(Redirect(controllers.callbacks.routes.SignInOutController.signOut))
   }
 
   def contact: Action[AnyContent] = isAuthenticatedWithProfileNoStatusCheck {

--- a/app/controllers/fileupload/DocumentUploadErrorController.scala
+++ b/app/controllers/fileupload/DocumentUploadErrorController.scala
@@ -36,7 +36,7 @@ class DocumentUploadErrorController @Inject()(view: UploadDocumentError,
 
   def show(): Action[AnyContent] = isAuthenticatedWithProfile() {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 }

--- a/app/controllers/fileupload/DocumentUploadTypeErrorController.scala
+++ b/app/controllers/fileupload/DocumentUploadTypeErrorController.scala
@@ -36,7 +36,7 @@ class DocumentUploadTypeErrorController @Inject()(view: UploadDocumentTypeError,
 
   def show(): Action[AnyContent] = isAuthenticatedWithProfile() {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view()))
   }
 }

--- a/app/controllers/grs/PartnerSoleTraderIdController.scala
+++ b/app/controllers/grs/PartnerSoleTraderIdController.scala
@@ -108,7 +108,7 @@ class PartnerSoleTraderIdController @Inject()(val sessionService: SessionService
           validateIndexSubmit(index, routes.PartnerSoleTraderIdController.startJourney, minIndex = 1) {
             for {
               (transactorDetails, soleTrader) <- soleTraderIdentificationService.retrieveSoleTraderDetails(journeyId)
-              _ <- if (index == leadEntityIndex) applicantDetailsService.saveApplicantDetails(transactorDetails) else Future.successful()
+              _ <- if (index == leadEntityIndex) applicantDetailsService.saveApplicantDetails(transactorDetails) else Future.successful(())
               _ <- entityService.upsertEntity[BusinessEntity](profile.registrationId, index, soleTrader)
             } yield {
               if (index == leadEntityIndex) {

--- a/app/controllers/grs/TransactorIdController.scala
+++ b/app/controllers/grs/TransactorIdController.scala
@@ -43,7 +43,7 @@ class TransactorIdController @Inject()(val sessionService: SessionService,
   def startJourney(): Action[AnyContent] =
     isAuthenticatedWithProfile() {
       implicit request =>
-        implicit profile =>
+        _ =>
           soleTraderIdentificationService.startIndividualJourney(
             SoleTraderIdJourneyConfig(
               continueUrl = appConfig.transactorCallbackUrl,

--- a/app/controllers/otherbusinessinvolvements/OtherBusinessCheckAnswersController.scala
+++ b/app/controllers/otherbusinessinvolvements/OtherBusinessCheckAnswersController.scala
@@ -55,7 +55,7 @@ class OtherBusinessCheckAnswersController @Inject()(val bcc: BaseControllerCompo
     }
   }
 
-  def submit(): Action[AnyContent] = isAuthenticatedWithProfile() { implicit request => implicit profile =>
+  def submit(): Action[AnyContent] = isAuthenticatedWithProfile() { _ => _ =>
     Future.successful(Redirect(routes.ObiSummaryController.show))
   }
 

--- a/app/controllers/partners/PartnerEntityTypeController.scala
+++ b/app/controllers/partners/PartnerEntityTypeController.scala
@@ -66,8 +66,8 @@ class PartnerEntityTypeController @Inject()(val authConnector: AuthConnector,
             result <- PartnerForm.form.bindFromRequest().fold(
               formWithErrors => Future.successful(BadRequest(partnerEntityTypePage(formWithErrors, isTransactor = true, index))),
               {
-                case partyType@Individual =>
-                  entityService.upsertEntity[PartyType](profile.registrationId, index, partyType).map { _ =>
+                case Individual =>
+                  entityService.upsertEntity[PartyType](profile.registrationId, index, Individual).map { _ =>
                     Redirect(grsRoutes.PartnerSoleTraderIdController.startJourney(index))
                   }
                 case _@BusinessEntity =>

--- a/app/controllers/sicandcompliance/SicController.scala
+++ b/app/controllers/sicandcompliance/SicController.scala
@@ -21,7 +21,7 @@ import controllers.BaseController
 import featureswitch.core.config.{FeatureSwitching, StubIcl}
 import models.CurrentProfile
 import models.ModelKeys.SIC_CODES_KEY
-import play.api.i18n.{Lang, Messages}
+import play.api.i18n.Lang
 import play.api.mvc.{Action, AnyContent, Result}
 import services._
 import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
@@ -75,7 +75,7 @@ class SicController @Inject()(val authConnector: AuthClientConnector,
         }
   }
 
-  private def startSelectingNewSicCodes(implicit hc: HeaderCarrier, cp: CurrentProfile, messages: Messages): Future[Result] = {
+  private def startSelectingNewSicCodes(implicit hc: HeaderCarrier, cp: CurrentProfile): Future[Result] = {
     if (isEnabled(StubIcl)) {
       Future.successful(Redirect(controllers.test.routes.SicStubController.show))
     } else {

--- a/app/controllers/test/AddressLookupStubController.scala
+++ b/app/controllers/test/AddressLookupStubController.scala
@@ -46,7 +46,7 @@ class AddressLookupStubController @Inject()(val configConnect: ConfigConnector,
     }
   }
 
-  def retrieve(id: String): Action[AnyContent] = Action.async { implicit request =>
+  def retrieve(id: String): Action[AnyContent] = Action.async { _ =>
     Future.successful(
       Ok(Json.obj(
         "auditRef" -> "auditRef",

--- a/app/controllers/test/BankAccountReputationStubController.scala
+++ b/app/controllers/test/BankAccountReputationStubController.scala
@@ -21,10 +21,9 @@ import play.api.mvc.{Action, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class BankAccountReputationStubController @Inject()(mcc: MessagesControllerComponents)
-                                                   (implicit ec: ExecutionContext) extends FrontendController(mcc) {
+class BankAccountReputationStubController @Inject()(mcc: MessagesControllerComponents) extends FrontendController(mcc) {
 
   def validateBankDetails(): Action[JsValue] = Action.async(parse.json) { implicit request =>
     val sortCode = (request.body \\ "sortCode").head.as[String]

--- a/app/controllers/test/EmailVerificationStubController.scala
+++ b/app/controllers/test/EmailVerificationStubController.scala
@@ -18,13 +18,12 @@ package controllers.test
 
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class EmailVerificationStubController @Inject()(mcc: MessagesControllerComponents)
-  extends FrontendController(mcc) {
+class EmailVerificationStubController @Inject()(mcc: MessagesControllerComponents) extends FrontendController(mcc) {
 
   def requestEmailVerificationPasscode: Action[JsValue] = Action(parse.json) {
      request =>

--- a/app/controllers/test/PersonalDetailsValidationStubController.scala
+++ b/app/controllers/test/PersonalDetailsValidationStubController.scala
@@ -18,7 +18,7 @@ package controllers.test
 
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}

--- a/app/controllers/test/SicStubController.scala
+++ b/app/controllers/test/SicStubController.scala
@@ -50,7 +50,7 @@ class SicStubController @Inject()(val configConnect: ConfigConnector,
 
   def show: Action[AnyContent] = isAuthenticatedWithProfile(checkTrafficManagement = false) {
     implicit request =>
-      implicit profile =>
+      _ =>
         Future.successful(Ok(view(SicStubForm.form)))
   }
 

--- a/app/controllers/test/UpdateTrafficManagementController.scala
+++ b/app/controllers/test/UpdateTrafficManagementController.scala
@@ -20,7 +20,7 @@ import config.FrontendAppConfig
 import connectors.test.TestVatRegistrationConnector
 import forms.test.UpdateTrafficManagementFormProvider
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.test.update_traffic_management
 
 import javax.inject.Inject

--- a/app/controllers/transactor/AgentNameController.scala
+++ b/app/controllers/transactor/AgentNameController.scala
@@ -44,7 +44,7 @@ class AgentNameController @Inject()(val authConnector: AuthConnector,
     for {
       transactorDetails <- transactorDetailsService.getTransactorDetails
       optPersonalDetails = transactorDetails.personalDetails
-      filledForm = optPersonalDetails.fold(form())(details => form().fill(details.firstName, details.lastName))
+      filledForm = optPersonalDetails.fold(form())(details => form().fill((details.firstName, details.lastName)))
     } yield Ok(view(filledForm))
   }
 

--- a/app/controllers/vatapplication/ReceiveGoodsNipController.scala
+++ b/app/controllers/vatapplication/ReceiveGoodsNipController.scala
@@ -44,7 +44,7 @@ class ReceiveGoodsNipController @Inject()(val sessionService: SessionService,
       implicit profile =>
         vatApplicationService.getVatApplication.map { vatApplication =>
           vatApplication.northernIrelandProtocol match {
-            case Some(NIPTurnover(_, Some(ConditionalValue(receiveGoods, amount)))) => Ok(view(ReceiveGoodsNipForm.form.fill(receiveGoods, amount)))
+            case Some(NIPTurnover(_, Some(ConditionalValue(receiveGoods, amount)))) => Ok(view(ReceiveGoodsNipForm.form.fill((receiveGoods, amount))))
             case _ => Ok(view(ReceiveGoodsNipForm.form))
           }
         }

--- a/app/controllers/vatapplication/SellOrMoveNipController.scala
+++ b/app/controllers/vatapplication/SellOrMoveNipController.scala
@@ -43,7 +43,7 @@ class SellOrMoveNipController @Inject()(val sessionService: SessionService,
         vatApplicationService.getVatApplication.map { r =>
           r.northernIrelandProtocol match {
             case Some(NIPTurnover(Some(ConditionalValue(answer, amount)), _)) =>
-              Ok(view(SellOrMoveNipForm.form.fill(answer, amount)))
+              Ok(view(SellOrMoveNipForm.form.fill((answer, amount))))
             case _ => Ok(view(SellOrMoveNipForm.form))
           }
         }

--- a/app/featureswitch/api/services/FeatureSwitchService.scala
+++ b/app/featureswitch/api/services/FeatureSwitchService.scala
@@ -37,9 +37,8 @@ class FeatureSwitchService @Inject()(featureSwitchRegistry: FeatureSwitchRegistr
   def updateFeatureSwitches(updatedFeatureSwitches: Seq[FeatureSwitchSetting]): Seq[FeatureSwitchSetting] = {
     updatedFeatureSwitches.foreach(
       featureSwitchSetting =>
-        featureSwitchRegistry.get(featureSwitchSetting.configName) match {
-          case Some(featureSwitch) =>
-            if (featureSwitchSetting.isEnabled) enable(featureSwitch) else disable(featureSwitch)
+        featureSwitchRegistry.get(featureSwitchSetting.configName).collect {
+          case featureSwitch => if (featureSwitchSetting.isEnabled) enable(featureSwitch) else disable(featureSwitch)
         }
     )
 

--- a/app/featureswitch/frontend/controllers/FeatureSwitchFrontendController.scala
+++ b/app/featureswitch/frontend/controllers/FeatureSwitchFrontendController.scala
@@ -22,7 +22,7 @@ import featureswitch.frontend.services.FeatureSwitchRetrievalService
 import featureswitch.frontend.views.html.feature_switch
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext

--- a/app/forms/AttachmentMethodForm.scala
+++ b/app/forms/AttachmentMethodForm.scala
@@ -50,7 +50,7 @@ object AttachmentMethodForm {
         case Some(Options.Upload) => Right(Attached)
         case Some(Options.Post) => Right(Post)
         case Some(Options.Email) => Right(EmailMethod)
-        case None => Left(Seq(FormError(key, Messages.invalidSelection)))
+        case _ => Left(Seq(FormError(key, Messages.invalidSelection)))
       }
     }
 

--- a/app/forms/TradingDetailsForms.scala
+++ b/app/forms/TradingDetailsForms.scala
@@ -75,9 +75,9 @@ object TradingNameForm extends RequiredBooleanForm {
   def fillWithPrePop(business: Business): Form[(Boolean, Option[String])] = {
     (business.hasTradingName, business.tradingName) match {
       case (Some(hasTradingName), optTradingName) =>
-        form.fill(hasTradingName, optTradingName)
+        form.fill((hasTradingName, optTradingName))
       case (None, optTradingName) if optTradingName.isDefined =>
-        form.fill(true, optTradingName)
+        form.fill((true, optTradingName))
       case _ =>
         form
     }

--- a/app/models/api/Address.scala
+++ b/app/models/api/Address.scala
@@ -21,7 +21,7 @@ import models.api.Address.inlineShow.inline
 import models.view.HomeAddressView
 import models.view.vatContact.ppob.PpobView
 import models.{ApiModelTransformer => MT}
-import org.apache.commons.lang3.text.WordUtils
+import org.apache.commons.text.WordUtils
 import play.api.libs.json._
 
 case class Country(code: Option[String], name: Option[String])

--- a/app/models/api/Attachments.scala
+++ b/app/models/api/Attachments.scala
@@ -32,8 +32,6 @@ object Attachments {
 
 sealed trait AttachmentMethod
 
-case object OtherAttachmentMethod extends AttachmentMethod
-
 case object Attached extends AttachmentMethod
 
 case object Post extends AttachmentMethod
@@ -42,7 +40,6 @@ case object EmailMethod extends AttachmentMethod
 
 object AttachmentMethod {
   val map: Map[AttachmentMethod, String] = Map(
-    OtherAttachmentMethod -> "1",
     Attached -> "2",
     Post -> "3",
     EmailMethod -> "email"

--- a/app/models/external/Name.scala
+++ b/app/models/external/Name.scala
@@ -19,7 +19,7 @@ package models.external
 
 import cats.Show
 import cats.Show.show
-import org.apache.commons.lang3.text.WordUtils
+import org.apache.commons.text.WordUtils
 import play.api.libs.json._
 
 case class Name(first: Option[String],

--- a/app/models/test/SicStubSelection.scala
+++ b/app/models/test/SicStubSelection.scala
@@ -40,7 +40,7 @@ object SicStubSelection {
   implicit val format = Format[SicStubSelection](
     Reads[SicStubSelection] {
       case JsString(`single`) => JsSuccess(SingleSicCode)
-      case JsString(singleCompliance) => JsSuccess(SingleSicCodeCompliance)
+      case JsString(`singleCompliance`) => JsSuccess(SingleSicCodeCompliance)
       case JsString(`multipleNoCompliance`) => JsSuccess(MultipleSicCodeNoCompliance)
       case JsString(`multipleCompliance`) => JsSuccess(MultipleSicCodeCompliance)
       case JsString(`custom`) => JsSuccess(CustomSicCodes)

--- a/app/services/BankAccountDetailsService.scala
+++ b/app/services/BankAccountDetailsService.scala
@@ -28,12 +28,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class BankAccountDetailsService @Inject()(val regApiConnector: RegistrationApiConnector,
                                           val bankAccountRepService: BankAccountReputationService) {
 
-  def fetchBankAccountDetails(implicit hc: HeaderCarrier, profile: CurrentProfile, ex: ExecutionContext): Future[Option[BankAccount]] = {
+  def fetchBankAccountDetails(implicit hc: HeaderCarrier, profile: CurrentProfile): Future[Option[BankAccount]] = {
     regApiConnector.getSection[BankAccount](profile.registrationId)
   }
 
   def saveBankAccountDetails(bankAccount: BankAccount)
-                            (implicit hc: HeaderCarrier, profile: CurrentProfile, ex: ExecutionContext): Future[BankAccount] = {
+                            (implicit hc: HeaderCarrier, profile: CurrentProfile): Future[BankAccount] = {
     regApiConnector.replaceSection[BankAccount](profile.registrationId, bankAccount)
   }
 
@@ -78,7 +78,7 @@ class BankAccountDetailsService @Inject()(val regApiConnector: RegistrationApiCo
   }
 
   def saveNoUkBankAccountDetails(reason: NoUKBankAccount)
-                                (implicit hc: HeaderCarrier, profile: CurrentProfile, ex: ExecutionContext): Future[BankAccount] = {
+                                (implicit hc: HeaderCarrier, profile: CurrentProfile): Future[BankAccount] = {
     val bankAccount = BankAccount(
       isProvided = false,
       details = None,

--- a/app/services/ICLService.scala
+++ b/app/services/ICLService.scala
@@ -46,6 +46,7 @@ class ICLService @Inject()(val iclConnector: ICLConnector,
     businessService.getBusiness flatMap { businessDetails =>
       businessDetails.businessActivities match {
         case Some(sicCodes) => Future.successful(sicCodes map (_.code))
+        case _ => Future.successful(Nil)
       }
     } recover {
       case e =>

--- a/app/services/NonRepudiationService.scala
+++ b/app/services/NonRepudiationService.scala
@@ -24,12 +24,11 @@ import uk.gov.hmrc.http.HeaderCarrier
 import utils.Base64Util
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 @Singleton
 class NonRepudiationService @Inject()(base64Util: Base64Util,
-                                      registrationApiConnector: RegistrationApiConnector)
-                                     (implicit ec: ExecutionContext) {
+                                      registrationApiConnector: RegistrationApiConnector) {
 
   def storeEncodedUserAnswers(regId: String, html: Html)(implicit hc: HeaderCarrier): Future[String] = {
     implicit val key: ApiKey[String] = nrsSubmissionPayloadKey

--- a/app/services/SoleTraderIdentificationService.scala
+++ b/app/services/SoleTraderIdentificationService.scala
@@ -24,11 +24,10 @@ import models.external.soletraderid.SoleTraderIdJourneyConfig
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 @Singleton
-class SoleTraderIdentificationService @Inject()(soleTraderIdentificationConnector: SoleTraderIdentificationConnector)
-                                               (implicit ec: ExecutionContext) {
+class SoleTraderIdentificationService @Inject()(soleTraderIdentificationConnector: SoleTraderIdentificationConnector) {
 
   def startSoleTraderJourney(config: SoleTraderIdJourneyConfig,
                              partyType: PartyType)

--- a/app/services/SummaryService.scala
+++ b/app/services/SummaryService.scala
@@ -16,7 +16,6 @@
 
 package services
 
-import config.FrontendAppConfig
 import models.CurrentProfile
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.accordion.Accordion
@@ -29,8 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SummaryService @Inject()(vatRegistrationService: VatRegistrationService,
                                summaryCheckYourAnswersBuilder: SummaryCheckYourAnswersBuilder
-                              )(implicit ec: ExecutionContext,
-                                appConfig: FrontendAppConfig) {
+                              )(implicit ec: ExecutionContext) {
 
   def getSummaryData(implicit hc: HeaderCarrier, profile: CurrentProfile, messages: Messages): Future[Accordion] = {
     for {

--- a/app/services/TimeService.scala
+++ b/app/services/TimeService.scala
@@ -66,7 +66,7 @@ class TimeService @Inject()(val bankHolidaysConnector: BankHolidaysConnector,
 
   val DATE_FORMAT = "yyyy-MM-dd"
 
-  def isDateSomeWorkingDaysInFuture(futureDate: LocalDate)(implicit bHS: BankHolidaySet): Boolean = {
+  def isDateSomeWorkingDaysInFuture(futureDate: LocalDate): Boolean = {
     isEqualOrAfter(getMinWorkingDayInFuture, futureDate)
   }
 
@@ -83,8 +83,6 @@ class TimeService @Inject()(val bankHolidaysConnector: BankHolidaysConnector,
       3
     }
   }
-
-  def futureWorkingDate(days: Int)(implicit bHS: BankHolidaySet): LocalDate = addWorkingDays(currentLocalDate, days)
 
   def addMonths(months: Int): LocalDate = currentLocalDate.plusMonths(months)
 

--- a/app/viewmodels/AboutTheBusinessSummaryBuilder.scala
+++ b/app/viewmodels/AboutTheBusinessSummaryBuilder.scala
@@ -239,7 +239,7 @@ class AboutTheBusinessSummaryBuilder @Inject()(govukSummaryList: GovukSummaryLis
     )
 
   private def zeroRatedTurnover(vatScheme: VatScheme)(implicit messages: Messages): Option[SummaryListRow] =
-    if (vatScheme.vatApplication.flatMap(_.turnoverEstimate).contains(0)) None else optSummaryListRowString(
+    if (vatScheme.vatApplication.flatMap(_.turnoverEstimate).contains(BigDecimal(0))) None else optSummaryListRowString(
       s"$sectionId.zeroRated",
       vatScheme.vatApplication.flatMap(_.zeroRatedSupplies.map(Formatters.currency)),
       Some(vatApplicationRoutes.ZeroRatedSuppliesController.show.url)

--- a/app/viewmodels/ApplicantDetailsSummaryBuilder.scala
+++ b/app/viewmodels/ApplicantDetailsSummaryBuilder.scala
@@ -196,6 +196,7 @@ class ApplicantDetailsSummaryBuilder @Inject()(govukSummaryList: GovukSummaryLis
         case Individual | NETP => Some(grsRoutes.PartnerSoleTraderIdController.startJourney(leadEntityIndex).url)
         case UkCompany | RegSociety | CharitableOrg => Some(grsRoutes.PartnerIncorpIdController.startJourney(leadEntityIndex).url)
         case ScotPartnership | ScotLtdPartnership | LtdLiabilityPartnership => Some(grsRoutes.PartnerPartnershipIdController.startJourney(leadEntityIndex).url)
+        case _ => None
       }
       val uniqueTaxpayerReference = partner.details match {
         case Some(soleTrader: SoleTraderIdEntity) =>

--- a/app/viewmodels/ManageRegistrationsBuilder.scala
+++ b/app/viewmodels/ManageRegistrationsBuilder.scala
@@ -17,7 +17,6 @@
 package viewmodels
 
 import common.enums.VatRegStatus
-import config.FrontendAppConfig
 import featureswitch.core.config.FeatureSwitching
 import models.api.VatSchemeHeader
 import play.api.i18n.Messages
@@ -31,8 +30,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.tag.Tag
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
-class ManageRegistrationsBuilder @Inject()(appConfig: FrontendAppConfig,
-                                           govukTag: GovukTag) extends FeatureSwitching {
+class ManageRegistrationsBuilder @Inject()(govukTag: GovukTag) extends FeatureSwitching {
 
   private final val GREY = "govuk-tag--grey"
   private final val YELLOW = "govuk-tag--yellow"

--- a/app/viewmodels/tasklist/AboutTheBusinessTaskList.scala
+++ b/app/viewmodels/tasklist/AboutTheBusinessTaskList.scala
@@ -16,14 +16,12 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import controllers.partners.PartnerIndexValidation.minPartnerIndex
 import featureswitch.core.config.{DigitalPartnerFlow, FeatureSwitching, LandAndProperty, OtherBusinessInvolvement => OBI_FS}
 import models.api._
 import models.external.{MinorEntity, PartnershipIdEntity}
 import models.{Business, CurrentProfile, Entity, OtherBusinessInvolvement}
 import play.api.i18n.Messages
-import play.api.mvc.Request
 import services.BusinessService
 
 import javax.inject.{Inject, Singleton}
@@ -158,10 +156,8 @@ class AboutTheBusinessTaskList @Inject()(aboutYouTaskList: AboutYouTaskList, bus
   }
 
   def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection =
+           (implicit profile: CurrentProfile,
+            messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.aboutTheBusiness.heading"),
       rows = Seq(

--- a/app/viewmodels/tasklist/AboutYouTaskList.scala
+++ b/app/viewmodels/tasklist/AboutYouTaskList.scala
@@ -16,12 +16,9 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import featureswitch.core.config.{FeatureSwitching, UseSoleTraderIdentification}
 import models.CurrentProfile
 import models.api._
-import play.api.i18n.Messages
-import play.api.mvc.Request
 import uk.gov.hmrc.http.InternalServerException
 
 import javax.inject.{Inject, Singleton}
@@ -162,10 +159,7 @@ class AboutYouTaskList @Inject()(verifyBusinessTaskList: VerifyBusinessTaskList,
   }
 
   def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection =
+           (implicit profile: CurrentProfile): TaskListSection =
     TaskListSection(
       heading = buildMessageKey("heading", vatScheme),
       rows = Seq(

--- a/app/viewmodels/tasklist/AboutYouTransactorTaskList.scala
+++ b/app/viewmodels/tasklist/AboutYouTransactorTaskList.scala
@@ -16,12 +16,10 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import featureswitch.core.config.{FeatureSwitching, FullAgentJourney}
 import models.CurrentProfile
 import models.api.{NETP, NonUkNonEstablished, VatScheme}
 import play.api.i18n.Messages
-import play.api.mvc.Request
 import uk.gov.hmrc.http.InternalServerException
 
 import javax.inject.Inject
@@ -101,10 +99,8 @@ class AboutYouTransactorTaskList @Inject()(registrationReasonTaskList: Registrat
   }
 
   def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection = {
+           (implicit profile: CurrentProfile,
+            messages: Messages): TaskListSection = {
 
     val isTransactor = vatScheme.eligibilitySubmissionData.exists(_.isTransactor)
     val isAgent = isTransactor && profile.agentReferenceNumber.nonEmpty

--- a/app/viewmodels/tasklist/AttachmentsTaskList.scala
+++ b/app/viewmodels/tasklist/AttachmentsTaskList.scala
@@ -16,12 +16,10 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import featureswitch.core.config.FeatureSwitching
 import models._
 import models.api._
 import play.api.i18n.Messages
-import play.api.mvc.Request
 import services.AttachmentsService
 import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 
@@ -53,17 +51,11 @@ class AttachmentsTaskList @Inject()(vatRegistrationTaskList: VatRegistrationTask
       None
     }
 
-  def build(vatScheme: VatScheme, attachmentsRow: TaskListRowBuilder)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection = {
-
+  def build(vatScheme: VatScheme, attachmentsRow: TaskListRowBuilder)(implicit messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.attachments.heading"),
       rows = Seq(attachmentsRow.build(vatScheme))
     )
-  }
 
   private def resolveMessageKey(attachments: List[AttachmentType]): String = {
     val documentsKey = "tasklist.attachments.identityDocuments"
@@ -97,6 +89,7 @@ class AttachmentsTaskList @Inject()(vatRegistrationTaskList: VatRegistrationTask
             case _ => checkPassed ++ checkFailed
           }
         case Some(Post | EmailMethod) => checkPassed
+        case _ => checkFailed
       }
     }.getOrElse(checkFailed)
   }

--- a/app/viewmodels/tasklist/RegistrationReasonTaskList.scala
+++ b/app/viewmodels/tasklist/RegistrationReasonTaskList.scala
@@ -19,7 +19,6 @@ package viewmodels.tasklist
 import config.FrontendAppConfig
 import models.api.VatScheme
 import play.api.i18n.Messages
-import play.api.mvc.Request
 
 import javax.inject.{Inject, Singleton}
 
@@ -36,10 +35,7 @@ class RegistrationReasonTaskList @Inject()(appConfig: FrontendAppConfig) {
     prerequisites = _ => Seq()
   )
 
-  def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection =
+  def build(vatScheme: VatScheme)(implicit messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.eligibility.heading"),
       rows = Seq(registrationReasonRow(vatScheme.registrationId).build(vatScheme))

--- a/app/viewmodels/tasklist/SummaryTaskList.scala
+++ b/app/viewmodels/tasklist/SummaryTaskList.scala
@@ -16,11 +16,9 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import models.CurrentProfile
 import models.api.VatScheme
 import play.api.i18n.Messages
-import play.api.mvc.Request
 
 import javax.inject.Inject
 
@@ -45,14 +43,9 @@ class SummaryTaskList @Inject() (vatRegistrationTaskList: VatRegistrationTaskLis
   }
 
   def build(vatScheme: VatScheme, attachmentsTaskListRowBuilder: Option[TaskListRowBuilder])
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection = {
-
+           (implicit profile: CurrentProfile, messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.cya.heading"),
       rows = Seq(summaryRow(attachmentsTaskListRowBuilder).build(vatScheme))
     )
-  }
 }

--- a/app/viewmodels/tasklist/VatRegistrationTaskList.scala
+++ b/app/viewmodels/tasklist/VatRegistrationTaskList.scala
@@ -16,13 +16,11 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import featureswitch.core.config.{FeatureSwitching, OtherBusinessInvolvement, TaxRepPage}
 import models._
 import models.api.vatapplication.{AnnualStagger, OverseasCompliance, StoringWithinUk, VatApplication}
 import models.api.{NETP, NonUkNonEstablished, VatScheme}
 import play.api.i18n.Messages
-import play.api.mvc.Request
 import uk.gov.hmrc.http.InternalServerException
 
 import javax.inject.{Inject, Singleton}
@@ -128,12 +126,7 @@ class VatRegistrationTaskList @Inject()(aboutTheBusinessTaskList: AboutTheBusine
     prerequisites = _ => Seq(vatReturnsRow)
   )
 
-  def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection = {
-
+  def build(vatScheme: VatScheme)(implicit profile: CurrentProfile, messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.vatRegistration.heading"),
       rows = Seq(
@@ -144,7 +137,6 @@ class VatRegistrationTaskList @Inject()(aboutTheBusinessTaskList: AboutTheBusine
         resolveFlatRateSchemeRow(vatScheme).map(_.build(vatScheme))
       ).flatten
     )
-  }
 
   private def resolveBankDetailsRow(vatScheme: VatScheme)(implicit profile: CurrentProfile) = {
     if (Seq(NETP, NonUkNonEstablished).exists(vatScheme.partyType.contains)) None else Some(bankAccountDetailsRow)

--- a/app/viewmodels/tasklist/VerifyBusinessTaskList.scala
+++ b/app/viewmodels/tasklist/VerifyBusinessTaskList.scala
@@ -16,11 +16,9 @@
 
 package viewmodels.tasklist
 
-import config.FrontendAppConfig
 import models.CurrentProfile
 import models.api.VatScheme
 import play.api.i18n.Messages
-import play.api.mvc.Request
 
 import javax.inject.{Inject, Singleton}
 
@@ -43,11 +41,7 @@ class VerifyBusinessTaskList @Inject()(registrationReasonTaskList: RegistrationR
       }
   )
 
-  def build(vatScheme: VatScheme)
-           (implicit request: Request[_],
-            profile: CurrentProfile,
-            messages: Messages,
-            appConfig: FrontendAppConfig): TaskListSection =
+  def build(vatScheme: VatScheme)(implicit profile: CurrentProfile, messages: Messages): TaskListSection =
     TaskListSection(
       heading = messages("tasklist.verifyBusiness.heading"),
       rows = Seq(businessInfoRow.build(vatScheme))

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies(),
     PlayKeys.playDefaultPort := 9895,
     retrieveManaged := true,
-    evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     addTestReportOption(IntegrationTest, "int-test-reports"),
     TwirlKeys.templateImports ++= Seq(
       "play.twirl.api._",

--- a/it/connectors/AttachmentsConnectorISpec.scala
+++ b/it/connectors/AttachmentsConnectorISpec.scala
@@ -36,9 +36,6 @@ class AttachmentsConnectorISpec extends IntegrationSpecBase with AppAndStubs wit
 
   val attachmentUrl = "/vatreg/1/attachments"
 
-  val testStoreAttachmentsOtherResponseJson: JsObject = Json.obj(
-    "method" -> Some(OtherAttachmentMethod).toString,
-  )
   val testStoreAttachmentsAttachedResponseJson: JsObject = Json.obj(
     "method" -> Some(Attached).toString,
   )

--- a/it/connectors/SoleTraderIdentificationConnectorISpec.scala
+++ b/it/connectors/SoleTraderIdentificationConnectorISpec.scala
@@ -158,7 +158,7 @@ class SoleTraderIdentificationConnectorISpec extends IntegrationSpecBase with Ap
       stubGet(retrieveDetailsUrl, OK, Json.stringify(testSTIResponse))
       val res: (PersonalDetails, SoleTraderIdEntity) = await(connector.retrieveSoleTraderDetails(testJourneyId))
 
-      res mustBe(testPersonalDetails.copy(score = Some(1)), testSoleTrader)
+      res mustBe((testPersonalDetails.copy(score = Some(1)), testSoleTrader))
     }
 
     "return transactor details for NETP when STI returns OK" in new Setup {
@@ -185,7 +185,7 @@ class SoleTraderIdentificationConnectorISpec extends IntegrationSpecBase with Ap
       stubGet(retrieveDetailsUrl, OK, Json.stringify(testSTIResponse))
       val res: (PersonalDetails, SoleTraderIdEntity) = await(connector.retrieveSoleTraderDetails(testJourneyId))
 
-      res mustBe(testNetpPersonalDetails, testNetpSoleTrader)
+      res mustBe((testNetpPersonalDetails, testNetpSoleTrader))
     }
 
     "return transactor details for NETP when an overseas identifier is returned" in new Setup {
@@ -216,7 +216,7 @@ class SoleTraderIdentificationConnectorISpec extends IntegrationSpecBase with Ap
       stubGet(retrieveDetailsUrl, OK, Json.stringify(testSTIResponse))
       val res: (PersonalDetails, SoleTraderIdEntity) = await(connector.retrieveSoleTraderDetails(testJourneyId))
 
-      res mustBe(testNetpPersonalDetails, testNetpSoleTrader.copy(overseas = Some(OverseasIdentifierDetails("123456789", "FR"))))
+      res mustBe((testNetpPersonalDetails, testNetpSoleTrader.copy(overseas = Some(OverseasIdentifierDetails("123456789", "FR")))))
     }
 
     "throw an InternalServerException when relevant fields are missing OK" in new Setup {

--- a/it/connectors/UpscanConnectorISpec.scala
+++ b/it/connectors/UpscanConnectorISpec.scala
@@ -24,10 +24,9 @@ import models.api.{AttachmentType, PrimaryIdentityEvidence}
 import models.external.upscan.{InProgress, UpscanDetails, UpscanResponse}
 import play.api.http.Status.NO_CONTENT
 import play.api.libs.json.{JsArray, JsObject, Json}
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import support.AppAndStubs
-import uk.gov.hmrc.http.{InternalServerException, NotFoundException, Upstream5xxResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{InternalServerException, NotFoundException, Upstream4xxResponse, Upstream5xxResponse}
 
 class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITRegistrationFixtures {
 
@@ -67,7 +66,6 @@ class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITR
 
 
   "upscanInitiate" must {
-    implicit val rq = FakeRequest()
     "return an UpscanResponse" in {
       stubPost(upscanInitiateUrl, OK, testUpscanResponseJson.toString())
       val requestBody = Json.obj(
@@ -148,7 +146,7 @@ class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITR
 
       stubDelete(upscanDetailsUrl, IM_A_TEAPOT, "")
 
-      intercept[UpstreamErrorResponse](await(connector.deleteUpscanDetails(testRegId, testReference)))
+      intercept[Upstream4xxResponse](await(connector.deleteUpscanDetails(testRegId, testReference)))
     }
   }
 
@@ -165,7 +163,7 @@ class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITR
     "return an exception if delete fails" in {
       stubDelete(deleteAllUpscanDetailsUrl, IM_A_TEAPOT, "")
 
-      intercept[UpstreamErrorResponse](await(connector.deleteAllUpscanDetails(testRegId)))
+      intercept[Upstream4xxResponse](await(connector.deleteAllUpscanDetails(testRegId)))
     }
   }
 
@@ -180,7 +178,7 @@ class UpscanConnectorISpec extends IntegrationSpecBase with AppAndStubs with ITR
 
     "return an exception if fetch fails" in {
       stubGet(upscanFilesUrl, INTERNAL_SERVER_ERROR, JsArray(List(testUpscanDetailsJson)).toString())
-      intercept[UpstreamErrorResponse](await(connector.fetchAllUpscanDetails(testRegId)))
+      intercept[Upstream5xxResponse](await(connector.fetchAllUpscanDetails(testRegId)))
     }
   }
 }

--- a/it/controllers/SummaryControllerISpec.scala
+++ b/it/controllers/SummaryControllerISpec.scala
@@ -81,6 +81,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.ApplicationSubmissionController.show.url)
@@ -98,6 +99,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.errors.routes.ErrorController.alreadySubmitted.url)
@@ -115,6 +117,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.SubmissionInProgressController.show.url)
@@ -132,6 +135,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.errors.routes.ErrorController.submissionFailed.url)
@@ -149,6 +153,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.errors.routes.ErrorController.submissionRetryable.url)
@@ -166,6 +171,7 @@ class SummaryControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfileIncorp, sessionId)
 
         val response: Future[WSResponse] = buildClient("/check-confirm-answers").post(Map("" -> Seq("")))
+
         whenReady(response) { res =>
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(controllers.errors.routes.ErrorController.contact.url)

--- a/it/controllers/attachments/AttachmentMethodControllerISpec.scala
+++ b/it/controllers/attachments/AttachmentMethodControllerISpec.scala
@@ -147,21 +147,6 @@ class AttachmentMethodControllerISpec extends ControllerISpec with ITRegistratio
         res.status mustBe BAD_REQUEST
       }
     }
-
-    "unsupported attachment method selection" must {
-      "return BAD_REQUEST" in new Setup {
-        given
-          .user.isAuthorised()
-          .registrationApi.replaceSection[Attachments](Attachments(Some(OtherAttachmentMethod)))
-
-
-        insertCurrentProfileIntoDb(currentProfile, sessionId)
-
-        val res = await(buildClient(url).post(Json.obj()))
-
-        res.status mustBe BAD_REQUEST
-      }
-    }
   }
 
 }

--- a/it/controllers/business/BusinessTelephoneNumberControllerISpec.scala
+++ b/it/controllers/business/BusinessTelephoneNumberControllerISpec.scala
@@ -17,10 +17,8 @@
 package controllers.business
 
 import itutil.ControllerISpec
-import models.api.{Trust, UkCompany}
-import models.{ApplicantDetails, Business}
+import models.Business
 import play.api.http.HeaderNames
-import play.api.libs.json.Format
 import play.api.libs.ws.WSResponse
 import play.api.test.Helpers._
 
@@ -31,7 +29,6 @@ class BusinessTelephoneNumberControllerISpec extends ControllerISpec {
 
   "show Business Telephone Number page" should {
     "return OK" in new Setup {
-      implicit val format: Format[ApplicantDetails] = ApplicantDetails.apiFormat(UkCompany)
       given()
         .user.isAuthorised()
 
@@ -46,7 +43,6 @@ class BusinessTelephoneNumberControllerISpec extends ControllerISpec {
 
   "submit Business Telephone Number page" should {
     "return SEE_OTHER" in new Setup {
-      implicit val format: Format[ApplicantDetails] = ApplicantDetails.apiFormat(Trust)
       given()
         .user.isAuthorised()
         .s4lContainer[Business].contains(Business())
@@ -62,7 +58,6 @@ class BusinessTelephoneNumberControllerISpec extends ControllerISpec {
     }
 
     "return BAD_REQUEST" in new Setup {
-      implicit val format: Format[ApplicantDetails] = ApplicantDetails.apiFormat(Trust)
       given()
         .user.isAuthorised()
         .s4lContainer[Business].contains(Business())

--- a/it/controllers/grs/IncorpIdControllerISpec.scala
+++ b/it/controllers/grs/IncorpIdControllerISpec.scala
@@ -24,8 +24,6 @@ import models.api._
 import models.external.IncorporatedEntity
 import play.api.libs.json.{Format, JsValue, Json}
 import play.api.libs.ws.WSResponse
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 class IncorpIdControllerISpec extends ControllerISpec {
@@ -34,8 +32,6 @@ class IncorpIdControllerISpec extends ControllerISpec {
 
   "GET /start-incorp-id-journey" should {
     "redirect to the returned journey url for UkCompany" in new Setup {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-
       disable(StubIncorpIdJourney)
 
       given()
@@ -56,8 +52,6 @@ class IncorpIdControllerISpec extends ControllerISpec {
     }
 
     "redirect to the returned journey url for RegSociety" in new Setup {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-
       disable(StubIncorpIdJourney)
 
       given()
@@ -78,8 +72,6 @@ class IncorpIdControllerISpec extends ControllerISpec {
     }
 
     "redirect to the returned journey url for CharitableOrg" in new Setup {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-
       disable(StubIncorpIdJourney)
 
       given()

--- a/it/controllers/grs/PartnerIncorpIdControllerISpec.scala
+++ b/it/controllers/grs/PartnerIncorpIdControllerISpec.scala
@@ -24,8 +24,6 @@ import models.api._
 import models.external.IncorporatedEntity
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSResponse
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 import scala.concurrent.Future
@@ -65,8 +63,6 @@ class PartnerIncorpIdControllerISpec extends ControllerISpec {
     }
 
     "redirect to the returned journey url for UkCompany" in new Setup {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-
       disable(StubIncorpIdJourney)
 
       given()

--- a/it/controllers/grs/PartnerSoleTraderIdControllerISpec.scala
+++ b/it/controllers/grs/PartnerSoleTraderIdControllerISpec.scala
@@ -216,7 +216,6 @@ class PartnerSoleTraderIdControllerISpec extends ControllerISpec {
     }
 
     "return INTERNAL_SERVER_ERROR if not party type available" in new Setup {
-      implicit val format: Format[ApplicantDetails] = ApplicantDetails.apiFormat(Partnership)
       given()
         .user.isAuthorised()
         .registrationApi.getSection[EligibilitySubmissionData](Some(testEligibilitySubmissionData.copy(partyType = Partnership)))

--- a/it/controllers/otherbusinessinvolvements/OtherBusinessCheckAnswersControllerISpec.scala
+++ b/it/controllers/otherbusinessinvolvements/OtherBusinessCheckAnswersControllerISpec.scala
@@ -3,7 +3,6 @@ package controllers.otherbusinessinvolvements
 
 import itutil.ControllerISpec
 import models.OtherBusinessInvolvement
-import org.jsoup.Jsoup
 import play.api.http.HeaderNames
 import play.api.test.Helpers._
 
@@ -39,7 +38,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
         val res = await(buildClient(url(testIndex1)).get)
-        val doc = Jsoup.parse(res.body)
 
         res.status mustBe OK
       }
@@ -56,7 +54,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
         insertCurrentProfileIntoDb(currentProfile, sessionId)
 
         val res = await(buildClient(url(testIndex1)).get)
-        val doc = Jsoup.parse(res.body)
 
         res.status mustBe OK
       }
@@ -75,7 +72,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
           insertCurrentProfileIntoDb(currentProfile, sessionId)
 
           val res = await(buildClient(url(testIndex2)).get)
-          val doc = Jsoup.parse(res.body)
 
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(routes.OtherBusinessCheckAnswersController.show(testIndex1).url)
@@ -94,7 +90,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
           insertCurrentProfileIntoDb(currentProfile, sessionId)
 
           val res = await(buildClient(url(testIndex3)).get)
-          val doc = Jsoup.parse(res.body)
 
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(routes.OtherBusinessCheckAnswersController.show(testIndex2).url)
@@ -111,7 +106,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
           insertCurrentProfileIntoDb(currentProfile, sessionId)
 
           val res = await(buildClient(url(testIndex4)).get)
-          val doc = Jsoup.parse(res.body)
 
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(routes.OtherBusinessCheckAnswersController.show(testIndex2).url)
@@ -141,7 +135,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
           insertCurrentProfileIntoDb(currentProfile, sessionId)
 
           val res = await(buildClient(url(testIndexOverMax)).get)
-          val doc = Jsoup.parse(res.body)
 
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(routes.OtherBusinessCheckAnswersController.show(testIndexMax).url)
@@ -160,7 +153,6 @@ class OtherBusinessCheckAnswersControllerISpec extends ControllerISpec {
           insertCurrentProfileIntoDb(currentProfile, sessionId)
 
           val res = await(buildClient(url(testIndexBelow1)).get)
-          val doc = Jsoup.parse(res.body)
 
           res.status mustBe SEE_OTHER
           res.header(HeaderNames.LOCATION) mustBe Some(routes.OtherBusinessCheckAnswersController.show(testIndex1).url)

--- a/it/controllers/sicandcompliance/SicControllerISpec.scala
+++ b/it/controllers/sicandcompliance/SicControllerISpec.scala
@@ -42,16 +42,6 @@ class SicControllerISpec extends ControllerISpec with RequestsFinder {
   }
 
   "User submitted on the sic halt page should redirect them to ICL, prepopping sic codes from VR" in new Setup {
-    val simplifiedSicJson =
-      """|{"businessActivities" : [
-         |           {
-         |               "code" : "43220",
-         |               "desc" : "Plumbing, heat and air-conditioning installation",
-         |               "indexes" : ""
-         |           }
-         |       ]
-         |}""".stripMargin
-
     given()
       .user.isAuthorised()
       .s4lContainer[Business].contains(fullModel)

--- a/it/helpers/ClientHelper.scala
+++ b/it/helpers/ClientHelper.scala
@@ -27,8 +27,8 @@ trait ClientHelper extends AuthHelper {
 
   implicit class RichClient(req: WSRequest) {
     def withSessionCookieHeader(userId: String = defaultUser): WSRequest =
-      req.withHeaders(HeaderNames.COOKIE -> getSessionCookie(userId = userId))
+      req.withHttpHeaders(HeaderNames.COOKIE -> getSessionCookie(userId = userId))
 
-    def withCSRFTokenHeader: WSRequest = req.withHeaders("Csrf-Token" -> "nocheck")
+    def withCSRFTokenHeader: WSRequest = req.withHttpHeaders("Csrf-Token" -> "nocheck")
   }
 }

--- a/it/itutil/WiremockHelper.scala
+++ b/it/itutil/WiremockHelper.scala
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.Application
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.crypto.json.JsonEncryptor
 import uk.gov.hmrc.crypto.{CryptoWithKeysFromConfig, Protected}
+import uk.gov.hmrc.crypto.json.JsonEncryptor
 
 import java.time.LocalDateTime
 

--- a/it/support/SessionCookieBaker.scala
+++ b/it/support/SessionCookieBaker.scala
@@ -63,7 +63,7 @@ object SessionCookieBaker extends IntegrationSpecBase {
     val decrypted = CompositeSymmetricCrypto.aesGCM(cookieKey, Seq()).decrypt(Crypted(cookieData)).value
     val result = decrypted.split("&")
       .map(_.split("="))
-      .map { case Array(k, v) => (k, URLDecoder.decode(v)) }
+      .map { case Array(k, v) => (k, URLDecoder.decode(v, java.nio.charset.Charset.defaultCharset().name())) }
       .toMap
 
     result

--- a/it/support/StubUtils.scala
+++ b/it/support/StubUtils.scala
@@ -37,7 +37,7 @@ trait StubUtils {
 
   final class RequestHolder(var request: FakeRequest[AnyContentAsFormUrlEncoded])
 
-  class PreconditionBuilder(implicit requestHolder: RequestHolder) {
+  class PreconditionBuilder {
 
     implicit val builder: PreconditionBuilder = this
 
@@ -67,7 +67,7 @@ trait StubUtils {
     def attachmentsApi = AttachmentsApiStub()
   }
 
-  def given()(implicit requestHolder: RequestHolder): PreconditionBuilder = {
+  def given(): PreconditionBuilder = {
     new PreconditionBuilder()
       .audit.writesAudit()
       .audit.writesAuditMerged()
@@ -204,7 +204,7 @@ trait StubUtils {
     }
   }
 
-  case class ICL()(implicit builder: PreconditionBuilder, requestHolder: RequestHolder) {
+  case class ICL()(implicit builder: PreconditionBuilder) {
     def setup(): PreconditionBuilder = {
       stubFor(
         post(urlPathEqualTo("/internal/initialise-journey"))
@@ -520,7 +520,7 @@ trait StubUtils {
       builder
     }
 
-    def getSectionFails[T: ApiKey](regId: String = "1")(implicit format: Format[T]): PreconditionBuilder = {
+    def getSectionFails[T: ApiKey](regId: String = "1"): PreconditionBuilder = {
       stubFor(
         get(urlPathEqualTo(s"/vatreg/registrations/$regId/sections/${ApiKey[T]}"))
           .willReturn(badRequest())
@@ -555,7 +555,7 @@ trait StubUtils {
       builder
     }
 
-    def deleteSection[T: ApiKey](regId: String = "1", optIdx: Option[Int] = None)(implicit format: Format[T]): PreconditionBuilder = {
+    def deleteSection[T: ApiKey](regId: String = "1", optIdx: Option[Int] = None): PreconditionBuilder = {
       val url = s"/vatreg/registrations/$regId/sections/${ApiKey[T]}${optIdx.fold("")(idx => s"/$idx")}"
       stubFor(
         delete(urlPathEqualTo(url))
@@ -563,7 +563,7 @@ trait StubUtils {
       builder
     }
 
-    def replaceSectionFails[T: ApiKey](regId: String = "1")(implicit format: Format[T]): PreconditionBuilder = {
+    def replaceSectionFails[T: ApiKey](regId: String = "1"): PreconditionBuilder = {
       stubFor(
         put(urlPathEqualTo(s"/vatreg/registrations/$regId/sections/${ApiKey[T]}"))
           .willReturn(badRequest())
@@ -590,7 +590,7 @@ trait StubUtils {
       builder
     }
 
-    def storeUpscanReference(reference: String, attachmentType: AttachmentType, regId: String = "1")(implicit format: Format[UpscanDetails]): PreconditionBuilder = {
+    def storeUpscanReference(reference: String, attachmentType: AttachmentType, regId: String = "1"): PreconditionBuilder = {
       stubFor(post(urlPathEqualTo(s"/vatreg/$regId/upscan-reference"))
         .withRequestBody(equalToJson(Json.stringify(Json.obj(
           "reference" -> reference,
@@ -601,7 +601,7 @@ trait StubUtils {
       builder
     }
 
-    def fetchUpscanFileDetails(upscanDetails: UpscanDetails, regId: String = "1", reference: String)(implicit format: Format[UpscanDetails]): PreconditionBuilder = {
+    def fetchUpscanFileDetails(upscanDetails: UpscanDetails, regId: String = "1", reference: String): PreconditionBuilder = {
       stubFor(get(urlPathEqualTo(s"/vatreg/$regId/upscan-file-details/$reference"))
         .willReturn(ok(Json.stringify(Json.toJson[UpscanDetails](upscanDetails)))
         ))
@@ -623,7 +623,7 @@ trait StubUtils {
       builder
     }
 
-    def deleteAttachments(regId: String = "1")(implicit writes: Writes[Attachments]): PreconditionBuilder = {
+    def deleteAttachments(regId: String = "1"): PreconditionBuilder = {
       stubFor(
         delete(urlPathMatching(s"/vatreg/$regId/upscan-file-details"))
           .willReturn(aResponse().withStatus(NO_CONTENT))
@@ -633,14 +633,14 @@ trait StubUtils {
   }
 
   case class AttachmentsApiStub()(implicit builder: PreconditionBuilder) {
-    def getAttachments(attachments: List[AttachmentType], regId: String = "1")(implicit format: Format[Attachments]): PreconditionBuilder = {
+    def getAttachments(attachments: List[AttachmentType], regId: String = "1"): PreconditionBuilder = {
       stubFor(get(urlPathEqualTo(s"/vatreg/$regId/attachments"))
         .willReturn(ok(Json.stringify(Json.toJson[List[AttachmentType]](attachments)))
         ))
       builder
     }
 
-    def getIncompleteAttachments(attachments: List[AttachmentType], regId: String = "1")(implicit format: Format[Attachments]): PreconditionBuilder = {
+    def getIncompleteAttachments(attachments: List[AttachmentType], regId: String = "1"): PreconditionBuilder = {
       stubFor(get(urlPathEqualTo(s"/vatreg/$regId/incomplete-attachments"))
         .willReturn(ok(Json.stringify(Json.toJson[List[AttachmentType]](attachments)))
         ))

--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -54,14 +54,14 @@ class AddressLookupConnectorSpec extends VatRegSpec with VatRegistrationFixture 
 
   "getOnRampUrl" should {
     "return a valid call to be used in a redirect" in new Setup {
-      val successfulResponse = HttpResponse(PERMANENT_REDIRECT, responseHeaders = Map(LOCATION -> Seq(redirectUrl)))
+      val successfulResponse = HttpResponse(PERMANENT_REDIRECT, headers = Map(LOCATION -> Seq(redirectUrl)), body = "")
       mockHttpPOST[JsObject, HttpResponse](appConfig.addressLookupJourneyUrl, successfulResponse)
 
       connector.getOnRampUrl(AddressLookupConstants.testAlfConfig) returns Call(GET, redirectUrl)
     }
 
     "throw an exception when address lookup service does not respond with redirect location" in new Setup {
-      val badResponse = HttpResponse(OK, responseHeaders = Map.empty)
+      val badResponse = HttpResponse(OK, headers = Map.empty, body = "")
       mockHttpPOST[JsObject, HttpResponse](appConfig.addressLookupJourneyUrl, badResponse)
 
       connector.getOnRampUrl(AddressLookupConstants.testAlfConfig) failedWith classOf[ALFLocationHeaderNotSetException]

--- a/test/connectors/AttachmentsConnectorSpec.scala
+++ b/test/connectors/AttachmentsConnectorSpec.scala
@@ -27,20 +27,10 @@ class AttachmentsConnectorSpec extends VatRegSpec {
 
   val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
   val connector = new AttachmentsConnector(mockHttpClient, appConfig)
-
   val testAttachmentList: List[AttachmentType] = List[AttachmentType](IdentityEvidence, TaxRepresentativeAuthorisation, OtherAttachments)
-
   val testEmptyAttachmentList: List[AttachmentType] = List[AttachmentType]()
-
-  val testStoreAttachmentsOtherResponseJson: JsObject = Json.obj(
-    "method" -> Some(OtherAttachmentMethod).toString,
-  )
-  val testStoreAttachmentsAttachedResponseJson: JsObject = Json.obj(
-    "method" -> Some(Attached).toString,
-  )
-  val testStoreAttachmentsPostResponseJson: JsObject = Json.obj(
-    "method" -> Some(Post).toString,
-  )
+  val testStoreAttachmentsAttachedResponseJson: JsObject = Json.obj("method" -> Some(Attached).toString)
+  val testStoreAttachmentsPostResponseJson: JsObject = Json.obj("method" -> Some(Post).toString)
 
   "getAttachments" should {
     "return a list of attachments" in {

--- a/test/connectors/BankAccountReputationConnectorSpec.scala
+++ b/test/connectors/BankAccountReputationConnectorSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito._
 import org.mockito._
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import testHelpers.VatRegSpec
-import uk.gov.hmrc.http.{HttpResponse, InternalServerException, Upstream5xxResponse}
+import uk.gov.hmrc.http.{HttpResponse, InternalServerException, UpstreamErrorResponse}
 
 import scala.concurrent.Future
 
@@ -48,7 +48,7 @@ class BankAccountReputationConnectorSpec extends VatRegSpec {
     "throw an exception" in new Setup {
       when(mockHttpClient.POST[BankAccountDetails, HttpResponse](ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
         (ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
-        .thenReturn(Future.failed(Upstream5xxResponse(INTERNAL_SERVER_ERROR.toString, 500, 500)))
+        .thenReturn(Future.failed(UpstreamErrorResponse(INTERNAL_SERVER_ERROR.toString, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)))
 
       connector.validateBankDetails(bankDetails) failedWith classOf[InternalServerException]
     }

--- a/test/connectors/PartnershipIDConnectorSpec.scala
+++ b/test/connectors/PartnershipIDConnectorSpec.scala
@@ -104,7 +104,7 @@ class PartnershipIDConnectorSpec extends VatRegSpec {
       val invalidGeneralPartnershipJson = {
         Json.toJson(testGeneralPartnership).as[JsObject] - "sautr"
       }
-      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Some(Json.obj("sautr" -> invalidGeneralPartnershipJson))))
+      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Json.stringify(Json.obj("sautr" -> invalidGeneralPartnershipJson))))
 
       intercept[InternalServerException] {
         await(connector.getDetails(testJourneyId))

--- a/test/connectors/SoleTraderIdentificationConnectorSpec.scala
+++ b/test/connectors/SoleTraderIdentificationConnectorSpec.scala
@@ -110,7 +110,7 @@ class SoleTraderIdentificationConnectorSpec extends VatRegSpec {
 
         mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, testSTIResponse.toString()))
         val res = await(connector.retrieveSoleTraderDetails(testJourneyId))
-        res mustBe(testPersonalDetails, testSoleTrader)
+        res mustBe((testPersonalDetails, testSoleTrader))
       }
     }
     "overseas details are returned" must {
@@ -138,14 +138,14 @@ class SoleTraderIdentificationConnectorSpec extends VatRegSpec {
 
         mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, testSTIResponse.toString()))
         val res = await(connector.retrieveSoleTraderDetails(testJourneyId))
-        res mustBe(testPersonalDetails, testSoleTrader.copy(overseas = Some(OverseasIdentifierDetails("1234", "ES"))))
+        res mustBe((testPersonalDetails, testSoleTrader.copy(overseas = Some(OverseasIdentifierDetails("1234", "ES")))))
       }
     }
     "throw an InternalServerException when relevant fields are missing OK" in new Setup {
       val invalidTransactorJson = {
         Json.toJson(testPersonalDetails).as[JsObject] - "firstName"
       }
-      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Some(Json.obj("personalDetails" -> invalidTransactorJson))))
+      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Json.stringify(Json.obj("personalDetails" -> invalidTransactorJson))))
 
       intercept[InternalServerException] {
         await(connector.retrieveSoleTraderDetails(testJourneyId))
@@ -218,7 +218,7 @@ class SoleTraderIdentificationConnectorSpec extends VatRegSpec {
       val invalidTransactorJson = {
         Json.toJson(testPersonalDetails).as[JsObject] - "firstName"
       }
-      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Some(Json.obj("personalDetails" -> invalidTransactorJson))))
+      mockHttpGET(retrieveDetailsUrl, HttpResponse(OK, Json.stringify(Json.obj("personalDetails" -> invalidTransactorJson))))
 
       intercept[InternalServerException] {
         await(connector.retrieveIndividualDetails(testJourneyId))

--- a/test/connectors/VatRegistrationConnectorSpec.scala
+++ b/test/connectors/VatRegistrationConnectorSpec.scala
@@ -21,6 +21,7 @@ import fixtures.VatRegistrationFixture
 import models.api._
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
+import play.api.http.Status.BAD_REQUEST
 import testHelpers.VatRegSpec
 import uk.gov.hmrc.http._
 

--- a/test/connectors/mocks/MockRegistrationApiConnector.scala
+++ b/test/connectors/mocks/MockRegistrationApiConnector.scala
@@ -69,8 +69,7 @@ trait MockRegistrationApiConnector {
       idx = ArgumentMatchers.any[Option[Int]]
     )(
       any[ApiKey[T]],
-      any[HeaderCarrier],
-      any[Format[T]]
+      any[HeaderCarrier]
     )).thenReturn(Future.successful(true))
 
 }

--- a/test/controllers/ApplicationSubmissionControllerSpec.scala
+++ b/test/controllers/ApplicationSubmissionControllerSpec.scala
@@ -78,24 +78,6 @@ class ApplicationSubmissionControllerSpec extends ControllerSpec with FutureAsse
       }
     }
 
-    "display the submission confirmation page to the user when IdentityEvidence is available and Method is Other" in {
-      mockAuthenticatedBasic
-      mockWithCurrentProfile(Some(currentProfile))
-
-      when(mockAttachmentsService.getAttachmentList(any())(any()))
-        .thenReturn(Future.successful(List(IdentityEvidence)))
-
-      when(mockAttachmentsService.getAttachmentDetails(any())(any()))
-        .thenReturn(Future.successful(Some(Attachments(method = Some(OtherAttachmentMethod)))))
-
-      when(vatRegistrationServiceMock.getAckRef(ArgumentMatchers.eq(validVatScheme.registrationId))(any()))
-        .thenReturn(Future.successful("123412341234"))
-
-      callAuthorised(testController.show) { res =>
-        status(res) mustBe OK
-      }
-    }
-
     "display the submission confirmation page to the user when IdentityEvidence is available and Method is Attached" in {
       mockAuthenticatedBasic
       mockWithCurrentProfile(Some(currentProfile))

--- a/test/controllers/BaseControllerSpec.scala
+++ b/test/controllers/BaseControllerSpec.scala
@@ -38,13 +38,11 @@ class BaseControllerSpec extends ControllerSpec with FeatureSwitching {
     val authConnector: AuthClientConnector = mockAuthClientConnector
 
     def callAuthenticated: Action[AnyContent] = isAuthenticated {
-      implicit request =>
-        Future.successful(Ok("ALL GOOD"))
+      _ => Future.successful(Ok("ALL GOOD"))
     }
 
     def callAuthenticatedButError: Action[AnyContent] = isAuthenticated {
-      implicit request =>
-        Future.failed(new Exception("Something wrong"))
+      _ => Future.failed(new Exception("Something wrong"))
     }
 
     def callAuthenticatedWithProfile(checkTrafficManagement: Boolean = true): Action[AnyContent] =

--- a/test/controllers/HonestyDeclarationControllerSpec.scala
+++ b/test/controllers/HonestyDeclarationControllerSpec.scala
@@ -21,7 +21,6 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import services.mocks.MockVatRegistrationService
 import testHelpers.ControllerSpec
-import uk.gov.hmrc.http.HttpResponse
 import views.html.honesty_declaration
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/controllers/applicant/CaptureRoleInTheBusinessSpec.scala
+++ b/test/controllers/applicant/CaptureRoleInTheBusinessSpec.scala
@@ -16,13 +16,13 @@
 
 package controllers.applicant
 
-import akka.actor.TypedActor.dispatcher
 import fixtures.ApplicantDetailsFixtures
 import models.Director
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import services.mocks.{MockApplicantDetailsService, MockVatRegistrationService}
 import testHelpers.ControllerSpec
 import views.html.applicant.role_in_the_business
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.Future
 
@@ -32,6 +32,7 @@ class CaptureRoleInTheBusinessSpec extends ControllerSpec
   with MockApplicantDetailsService
   with ApplicantDetailsFixtures
   with MockVatRegistrationService {
+
 
   trait Setup {
     val view: role_in_the_business = app.injector.instanceOf[role_in_the_business]

--- a/test/controllers/feedback/FeedbackControllerSpec.scala
+++ b/test/controllers/feedback/FeedbackControllerSpec.scala
@@ -55,9 +55,6 @@ class FeedbackControllerSpec extends ControllerSpec with FutureAssertions {
   }
 
   "POST /feedback" should {
-    val fakeRequest = FakeRequest("GET", "/")
-    val fakePostRequest = FakeRequest("POST", "/register-for-paye/feedback").withFormUrlEncodedBody("test" -> "test")
-
     "return form with thank you for valid selections" in new Setup {
       when(mockHttpClient.POSTForm[HttpResponse](ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(
         Future.successful(HttpResponse(Status.OK, "1234")))

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -68,10 +68,10 @@ trait VatRegistrationFixture extends BaseFixture with FlatRateFixtures with Appl
   val formattedThreshold = "50,000"
 
   //Responses
-  val forbidden = Upstream4xxResponse(FORBIDDEN.toString, FORBIDDEN, FORBIDDEN)
+  val forbidden = UpstreamErrorResponse(FORBIDDEN.toString, FORBIDDEN, FORBIDDEN)
   val noContent = HttpResponse(204, "")
-  val upstream4xx = Upstream4xxResponse(IM_A_TEAPOT.toString, IM_A_TEAPOT, IM_A_TEAPOT)
-  val upstream5xx = Upstream5xxResponse(INTERNAL_SERVER_ERROR.toString, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)
+  val upstream4xx = UpstreamErrorResponse(IM_A_TEAPOT.toString, IM_A_TEAPOT, IM_A_TEAPOT)
+  val upstream5xx = UpstreamErrorResponse(INTERNAL_SERVER_ERROR.toString, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)
   val validHttpResponse = HttpResponse(OK, "{}")
 
   // CacheMap from S4l
@@ -82,7 +82,7 @@ trait VatRegistrationFixture extends BaseFixture with FlatRateFixtures with Appl
   val notFound = new NotFoundException(NOT_FOUND.toString)
   val internalServiceException = new InternalServerException(BAD_GATEWAY.toString)
   val runTimeException = new RuntimeException("tst")
-  val internalServerError = Upstream5xxResponse(INTERNAL_SERVER_ERROR.toString, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)
+  val internalServerError = UpstreamErrorResponse(INTERNAL_SERVER_ERROR.toString, INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR)
   val exception = new Exception(BAD_GATEWAY.toString)
 
   //Test variables

--- a/test/forms/AttachmentMethodFormSpec.scala
+++ b/test/forms/AttachmentMethodFormSpec.scala
@@ -17,7 +17,6 @@
 package forms
 
 import models.api._
-import play.api.libs.json.Json
 import testHelpers.VatRegSpec
 
 class AttachmentMethodFormSpec extends VatRegSpec {
@@ -27,21 +26,21 @@ class AttachmentMethodFormSpec extends VatRegSpec {
   "The attachment method form" must {
     "bind" when {
       "upload is selected" in {
-        val res = form().bind(Json.obj("value" -> "2"))
+        val res = form().bind(Map("value" -> "2"))
         res.value mustBe Some(Attached)
       }
       "post is selected" in {
-        val res = form().bind(Json.obj("value" -> "3"))
+        val res = form().bind(Map("value" -> "3"))
         res.value mustBe Some(Post)
       }
       "email is selected" in {
-        val res = form().bind(Json.obj("value" -> "email"))
+        val res = form().bind(Map("value" -> "email"))
         res.value mustBe Some(EmailMethod)
       }
     }
     "return a form error" when {
       "nothing is selected" in {
-        val res = form().bind(Json.obj())
+        val res = form().bind(Map.empty[String, String])
         res.error("value").map(_.message) mustBe Some("attachmentMethod.error.missing")
       }
     }

--- a/test/forms/PartnerFormSpec.scala
+++ b/test/forms/PartnerFormSpec.scala
@@ -18,7 +18,6 @@ package forms
 
 import models.api._
 import play.api.data.{Form, FormError}
-import play.api.libs.json.Json
 import testHelpers.VatRegSpec
 
 class PartnerFormSpec extends VatRegSpec {
@@ -43,7 +42,7 @@ class PartnerFormSpec extends VatRegSpec {
 
       validEntityTypes map {
         case (value, expected) =>
-          val res = form.bind(Json.obj(PartnerForm.leadPartnerEntityType -> value))
+          val res = form.bind(Map(PartnerForm.leadPartnerEntityType -> value))
           res.get mustBe expected
       }
     }
@@ -55,7 +54,7 @@ class PartnerFormSpec extends VatRegSpec {
       )
 
       invalidEntityTypes map { value =>
-        val res = form.bind(Json.obj(PartnerForm.leadPartnerEntityType -> value))
+        val res = form.bind(Map(PartnerForm.leadPartnerEntityType -> value))
         res.errors.head mustBe FormError(PartnerForm.leadPartnerEntityType, Seq(errorKey), Seq())
       }
     }

--- a/test/forms/PaymentFrequencyFormSpec.scala
+++ b/test/forms/PaymentFrequencyFormSpec.scala
@@ -18,7 +18,6 @@ package forms
 
 import models.api.vatapplication._
 import play.api.data.{Form, FormError}
-import play.api.libs.json.Json
 import testHelpers.VatRegSpec
 
 class PaymentFrequencyFormSpec extends VatRegSpec {
@@ -35,7 +34,7 @@ class PaymentFrequencyFormSpec extends VatRegSpec {
 
         validValues.map {
           case (value, expected) =>
-            val res = form.bind(Json.obj(PaymentFrequencyForm.paymentFrequency -> value))
+            val res = form.bind(Map(PaymentFrequencyForm.paymentFrequency -> value))
             res.get mustBe expected
         }
       }
@@ -47,7 +46,7 @@ class PaymentFrequencyFormSpec extends VatRegSpec {
         )
 
         invalidValues map { value =>
-          val res = form.bind(Json.obj(PaymentFrequencyForm.paymentFrequency -> value))
+          val res = form.bind(Map(PaymentFrequencyForm.paymentFrequency -> value))
           res.errors.head mustBe FormError(PaymentFrequencyForm.paymentFrequency, Seq("aas.paymentFrequency.notProvided"), Seq())
         }
       }

--- a/test/forms/PaymentMethodFormSpec.scala
+++ b/test/forms/PaymentMethodFormSpec.scala
@@ -18,7 +18,6 @@ package forms
 
 import models.api.vatapplication.{BACS, BankGIRO, CHAPS, StandingOrder}
 import play.api.data.FormError
-import play.api.libs.json.Json
 import testHelpers.VatRegSpec
 
 class PaymentMethodFormSpec extends VatRegSpec {
@@ -37,7 +36,7 @@ class PaymentMethodFormSpec extends VatRegSpec {
 
         validValues map {
           case (value, expected) =>
-            val res = form.bind(Json.obj(PaymentMethodForm.paymentMethod -> value))
+            val res = form.bind(Map(PaymentMethodForm.paymentMethod -> value))
             res.get mustBe expected
         }
       }
@@ -48,7 +47,7 @@ class PaymentMethodFormSpec extends VatRegSpec {
         )
 
         invalidValues map { value =>
-          val res = form.bind(Json.obj(PaymentMethodForm.paymentMethod -> value))
+          val res = form.bind(Map(PaymentMethodForm.paymentMethod -> value))
           res.errors.head mustBe FormError(PaymentMethodForm.paymentMethod, Seq("aas.paymentMethod.error.required"), Seq())
         }
       }

--- a/test/forms/ReceiveGoodsNipFormSpec.scala
+++ b/test/forms/ReceiveGoodsNipFormSpec.scala
@@ -44,7 +44,7 @@ class ReceiveGoodsNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
     "validate that receiveGoodsNip is valid" in {
       val form = receiveGoodsNipForm.bind(Map(ReceiveGoodsNipForm.yesNo -> validYesNo, ReceiveGoodsNipForm.inputAmount -> testValidReceiveGoodsNip)).value
 
-      form mustBe Some(true, Some(validReceiveGoodsNip))
+      form mustBe Some((true, Some(validReceiveGoodsNip)))
     }
 
     "validate that missing yesNo answer fails" in {

--- a/test/forms/SellOrMoveNipFormSpec.scala
+++ b/test/forms/SellOrMoveNipFormSpec.scala
@@ -44,7 +44,7 @@ class SellOrMoveNipFormSpec extends PlaySpec with GuiceOneAppPerSuite {
     "validate that sellOrMoveNip is valid" in {
       val form = sellOrMoveNipForm.bind(Map(SellOrMoveNipForm.yesNo -> validYesNo, SellOrMoveNipForm.inputAmount -> testValidSellOrMoveNip)).value
 
-      form mustBe Some(true, Some(validSellOrMoveNip))
+      form mustBe Some((true, Some(validSellOrMoveNip)))
     }
 
     "validate that missing yesNo answer fails" in {

--- a/test/forms/TradingNameFormSpec.scala
+++ b/test/forms/TradingNameFormSpec.scala
@@ -58,23 +58,23 @@ class TradingNameFormSpec extends VatRegSpec {
     "be valid" when {
       "no is selected" in {
         val data = Map("value" -> Seq("false"))
-        testForm.bindFromRequest(data) shouldContainValue(false, None)
+        testForm.bindFromRequest(data) shouldContainValue((false, None))
       }
 
       "no is selected and a correct trading name is provided" in {
         val data = Map("value" -> Seq("false"), "tradingName" -> Seq(tradingName()))
-        testForm.bindFromRequest(data) shouldContainValue(false, None)
+        testForm.bindFromRequest(data) shouldContainValue((false, None))
       }
 
       "yes is selected and a correct trading name is provided" in {
         val data = Map("value" -> Seq("true"), "tradingName" -> Seq(tradingName()))
-        testForm.bindFromRequest(data) shouldContainValue(true, Some(tradingName()))
+        testForm.bindFromRequest(data) shouldContainValue((true, Some(tradingName())))
       }
 
       "yes is selected and a correct trading name is provided including an invalid word" in {
         TradingNameForm.invalidNameSet.foreach {
           invalidName =>
-            testForm.bind(Map("value" -> "true", "tradingName" -> tradingName(invalidName))) shouldContainValue(true, Some(tradingName(invalidName)))
+            testForm.bind(Map("value" -> "true", "tradingName" -> tradingName(invalidName))) shouldContainValue((true, Some(tradingName(invalidName))))
         }
       }
     }

--- a/test/forms/validation/FormValidationSpec.scala
+++ b/test/forms/validation/FormValidationSpec.scala
@@ -340,19 +340,19 @@ class FormValidationSpec extends AnyWordSpec with Inside with Inspectors with Ma
     val constraint = FormValidation.nonEmptyDate("testErrMsg")
 
     "return Valid if the tuple of strings provided has a day, month and year" in {
-      constraint("day", "month", "year") shouldBe Valid
+      constraint(("day", "month", "year")) shouldBe Valid
     }
 
     "return Invalid if the day in the tuple is missing" in {
-      constraint("", "month", "year") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("", "month", "year")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
 
     "return Invalid if the month in the tuple is missing" in {
-      constraint("day", "", "year") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("day", "", "year")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
 
     "return Invalid if the year in the tuple is missing" in {
-      constraint("day", "month", "") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("day", "month", "")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
   }
 
@@ -360,19 +360,19 @@ class FormValidationSpec extends AnyWordSpec with Inside with Inspectors with Ma
     val constraint = FormValidation.validDate("testErrMsg")
 
     "return Valid if the tuple of strings provided is a valid date" in {
-      constraint("30", "12", "2018") shouldBe Valid
+      constraint(("30", "12", "2018")) shouldBe Valid
     }
 
     "return Invalid if the provided dates day value is not a valid day" in {
-      constraint("50", "1", "2018") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("50", "1", "2018")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
 
     "return Invalid if the provided dates month value is not a valid month" in {
-      constraint("1", "20", "2018") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("1", "20", "2018")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
 
     "return Invalid if the provided dates year value is not a valid year" in {
-      constraint("1", "1", "zOlB") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint(("1", "1", "zOlB")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
   }
 
@@ -382,23 +382,23 @@ class FormValidationSpec extends AnyWordSpec with Inside with Inspectors with Ma
     val constraint = FormValidation.withinRange(minDate, maxDate, "beforeMinErrMsg", "afterMaxErrMsg", List(minDate.toString, maxDate.toString))
 
     "return Valid if the date is after the min date and before the max date" in {
-      constraint("15", "6", "2018") shouldBe Valid
+      constraint(("15", "6", "2018")) shouldBe Valid
     }
 
     "return Valid if the date is the same as the minimum date" in {
-      constraint("1", "1", "2018") shouldBe Valid
+      constraint(("1", "1", "2018")) shouldBe Valid
     }
 
     "return Valid if the date is the same as the maximum date" in {
-      constraint("31", "12", "2018") shouldBe Valid
+      constraint(("31", "12", "2018")) shouldBe Valid
     }
 
     "return Invalid if the date is before the minumum date with the correct error message" in {
-      constraint("31", "12", "2017") shouldBe Invalid(ValidationError("beforeMinErrMsg", minDate.toString, maxDate.toString))
+      constraint(("31", "12", "2017")) shouldBe Invalid(ValidationError("beforeMinErrMsg", minDate.toString, maxDate.toString))
     }
 
     "return Invalid if the date is after the maximum date with the correct error message" in {
-      constraint("1", "1", "2019") shouldBe Invalid(ValidationError("afterMaxErrMsg", minDate.toString, maxDate.toString))
+      constraint(("1", "1", "2019")) shouldBe Invalid(ValidationError("afterMaxErrMsg", minDate.toString, maxDate.toString))
     }
   }
 
@@ -409,15 +409,15 @@ class FormValidationSpec extends AnyWordSpec with Inside with Inspectors with Ma
     val moreThan4 = LocalDate.now().minusYears(6)
 
     "return Valid if the date is less than 4 years ago" in {
-      constraint(s"${lessThan4.getDayOfMonth}", s"${lessThan4.getMonthValue}", s"${lessThan4.getYear}") shouldBe Valid
+      constraint((s"${lessThan4.getDayOfMonth}", s"${lessThan4.getMonthValue}", s"${lessThan4.getYear}")) shouldBe Valid
     }
 
     "return Valid if the date is exactly 4 years ago" in {
-      constraint(s"${exactly4.getDayOfMonth}", s"${exactly4.getMonthValue}", s"${exactly4.getYear}") shouldBe Valid
+      constraint((s"${exactly4.getDayOfMonth}", s"${exactly4.getMonthValue}", s"${exactly4.getYear}")) shouldBe Valid
     }
 
     "return Invalid if the date is more than 4 years ago" in {
-      constraint(s"${moreThan4.getDayOfMonth}", s"${moreThan4.getMonthValue}", s"${moreThan4.getYear}") shouldBe Invalid(ValidationError("testErrMsg"))
+      constraint((s"${moreThan4.getDayOfMonth}", s"${moreThan4.getMonthValue}", s"${moreThan4.getYear}")) shouldBe Invalid(ValidationError("testErrMsg"))
     }
   }
 }

--- a/test/forms/vatapplication/MandatoryDateFormSpec.scala
+++ b/test/forms/vatapplication/MandatoryDateFormSpec.scala
@@ -37,7 +37,7 @@ class MandatoryDateFormSpec extends VatRegSpec {
         "value" -> DateSelection.calculated_date.toString
       )
 
-      form.bind(data).get mustBe(calculated_date, None)
+      form.bind(data).get mustBe((calculated_date, None))
     }
 
     "Fail to bind successfully for no selection" in {
@@ -72,7 +72,7 @@ class MandatoryDateFormSpec extends VatRegSpec {
         "date.year" -> testYear.toString
       )
 
-      form.bind(data).get mustBe(specific_date, Some(LocalDate.of(testYear, 5, 5)))
+      form.bind(data).get mustBe((specific_date, Some(LocalDate.of(testYear, 5, 5))))
     }
 
     "Bind successfully if the specified date is on the incorporation date" in {
@@ -82,7 +82,7 @@ class MandatoryDateFormSpec extends VatRegSpec {
         "date.month" -> s"${incorpDate.getMonthValue}",
         "date.year" -> s"${incorpDate.getYear}"
       )
-      form.bind(data).get mustBe(specific_date, Some(incorpDate))
+      form.bind(data).get mustBe((specific_date, Some(incorpDate)))
     }
 
     "Bind successfully if the specified date is on the calculated date" in {
@@ -92,7 +92,7 @@ class MandatoryDateFormSpec extends VatRegSpec {
         "date.month" -> calculatedDate.getMonthValue.toString,
         "date.year" -> calculatedDate.getYear.toString
       )
-      form.bind(data).get mustBe(specific_date, Some(calculatedDate))
+      form.bind(data).get mustBe((specific_date, Some(calculatedDate)))
     }
 
     "Fail to bind if the date specified is before the incorp date" in {

--- a/test/forms/vatapplication/VoluntaryDateFormIncorpSpec.scala
+++ b/test/forms/vatapplication/VoluntaryDateFormIncorpSpec.scala
@@ -48,7 +48,7 @@ class VoluntaryDateFormIncorpSpec extends VatRegSpec {
         "value"  -> "company_registration_date",
         "startDate"       -> ""
       )
-      form.bind(data).get mustBe (company_registration_date, None)
+      form.bind(data).get mustBe ((company_registration_date, None))
     }
 
     "Bind successfully for a business start date selection" in {
@@ -56,7 +56,7 @@ class VoluntaryDateFormIncorpSpec extends VatRegSpec {
         "value"  -> "business_start_date",
         "startDate"       -> ""
       )
-      form.bind(data).get mustBe (business_start_date, None)
+      form.bind(data).get mustBe ((business_start_date, None))
     }
 
     "Bind successfully for a valid specific date selection" in {
@@ -66,7 +66,7 @@ class VoluntaryDateFormIncorpSpec extends VatRegSpec {
         "startDate.month" -> "1",
         "startDate.year"  -> "2021"
       )
-      form.bind(data).get mustBe(specific_date, Some(LocalDate.of(2021, 1, 5)))
+      form.bind(data).get mustBe((specific_date, Some(LocalDate.of(2021, 1, 5))))
     }
 
     "Fail to bind successfully for no selection" in {

--- a/test/forms/vatapplication/VoluntaryDateFormSpec.scala
+++ b/test/forms/vatapplication/VoluntaryDateFormSpec.scala
@@ -54,7 +54,7 @@ class VoluntaryDateFormSpec extends VatRegSpec {
         "value" -> "company_registration_date",
         "startDate" -> ""
       )
-      form.bind(data).get mustBe (company_registration_date, None)
+      form.bind(data).get mustBe ((company_registration_date, None))
     }
 
     "Bind successfully for a business start date selection" in {
@@ -62,7 +62,7 @@ class VoluntaryDateFormSpec extends VatRegSpec {
         "value" -> "business_start_date",
         "startDate" -> ""
       )
-      form.bind(data).get mustBe (business_start_date, None)
+      form.bind(data).get mustBe ((business_start_date, None))
     }
 
     "Bind successfully with a date input" in {
@@ -72,7 +72,7 @@ class VoluntaryDateFormSpec extends VatRegSpec {
         "startDate.month" -> s"${validDate.getMonthValue}",
         "startDate.year"  -> s"${validDate.getYear}"
       )
-      form.bind(data).get mustBe (specific_date, Some(validDate))
+      form.bind(data).get mustBe ((specific_date, Some(validDate)))
     }
 
     "Bind successfully with a date 2 days from now" in {
@@ -82,7 +82,7 @@ class VoluntaryDateFormSpec extends VatRegSpec {
         "startDate.month" -> s"${lowerLimitDate.getMonthValue}",
         "startDate.year" -> s"${lowerLimitDate.getYear}"
       )
-      form.bind(data).get mustBe (specific_date, Some(lowerLimitDate))
+      form.bind(data).get mustBe ((specific_date, Some(lowerLimitDate)))
     }
 
     "Bind successfully with a date 3 months from now" in {
@@ -92,7 +92,7 @@ class VoluntaryDateFormSpec extends VatRegSpec {
         "startDate.month" -> s"${upperLimitDate.getMonthValue}",
         "startDate.year" -> s"${upperLimitDate.getYear}"
       )
-      form.bind(data).get mustBe (specific_date, Some(upperLimitDate))
+      form.bind(data).get mustBe ((specific_date, Some(upperLimitDate)))
     }
 
     "Fail to bind successfully for no input" in {

--- a/test/services/FlatRateServiceSpec.scala
+++ b/test/services/FlatRateServiceSpec.scala
@@ -377,7 +377,7 @@ class FlatRateServiceSpec extends VatSpec {
       when(mockS4LService.fetchAndGet[FlatRateScheme](any(), any(), any(), any()))
         .thenReturn(Future.successful(Some(incompleteS4l)))
 
-      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe(None, None)
+      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe((None, None))
     }
 
     "should get as different date if it does not match the vat start date" in new Setup() {
@@ -389,7 +389,7 @@ class FlatRateServiceSpec extends VatSpec {
           Some(incompleteS4l.copy(frsStart = Some(Start(Some(diffdate)))))
         ))
 
-      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe(Some(FRSDateChoice.DifferentDate), Some(diffdate))
+      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe((Some(FRSDateChoice.DifferentDate), Some(diffdate)))
     }
 
     "should get vat date if it matches the vat start date" in new Setup() {
@@ -399,7 +399,7 @@ class FlatRateServiceSpec extends VatSpec {
           Some(incompleteS4l.copy(frsStart = Some(Start(None))))
         ))
 
-      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe(Some(FRSDateChoice.VATDate), None)
+      await(service.getPrepopulatedStartDate(vatStartDate)) mustBe((Some(FRSDateChoice.VATDate), None))
     }
   }
 
@@ -513,7 +513,7 @@ class FlatRateServiceSpec extends VatSpec {
         .thenReturn(Future.successful(validBusinessWithNoDescriptionAndLabour))
       when(mockS4LService.save[FlatRateScheme](any())(any(), any(), any(), any()))
         .thenReturn(Future.successful(dummyCacheMap))
-      when(mockRegistrationApiConnector.deleteSection[FlatRateScheme](any(), any())(any(), any(), any()))
+      when(mockRegistrationApiConnector.deleteSection[FlatRateScheme](any(), any())(any(), any()))
         .thenReturn(Future.successful(true))
 
       await(service.resetFRSForSAC(newSicCode)) mustBe newSicCode
@@ -523,12 +523,12 @@ class FlatRateServiceSpec extends VatSpec {
     "reset Flat Rate Scheme and return true" in new Setup {
       when(mockS4LService.save[FlatRateScheme](any())(any(), any(), any(), any()))
         .thenReturn(Future.successful(dummyCacheMap))
-      when(mockRegistrationApiConnector.deleteSection[FlatRateScheme](any(), any())(any(), any(), any()))
+      when(mockRegistrationApiConnector.deleteSection[FlatRateScheme](any(), any())(any(), any()))
         .thenReturn(Future.successful(true))
 
       await(service.clearFrs) mustBe true
       verify(mockS4LService, times(1)).save(any())(any(), any(), any(), any())
-      verify(mockRegistrationApiConnector, times(1)).deleteSection[FlatRateScheme](any(), any())(any(), any(), any())
+      verify(mockRegistrationApiConnector, times(1)).deleteSection[FlatRateScheme](any(), any())(any(), any())
     }
   }
 

--- a/test/services/SoleTraderIdentificationServiceSpec.scala
+++ b/test/services/SoleTraderIdentificationServiceSpec.scala
@@ -94,7 +94,7 @@ class SoleTraderIdentificationServiceSpec extends VatRegSpec
 
       val res = await(Service.retrieveSoleTraderDetails(testJourneyUrl))
 
-      res mustBe(testPersonalDetails, testSoleTrader)
+      res mustBe((testPersonalDetails, testSoleTrader))
     }
   }
 

--- a/test/services/TimeServiceSpec.scala
+++ b/test/services/TimeServiceSpec.scala
@@ -62,104 +62,88 @@ class TimeServiceSpec extends AnyWordSpec with MockFactory with Inspectors with 
     // Before 2pm, no bank holiday
     "return true when a date 3 days away is supplied before 2pm and does not conflict with any bank holidays" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 12, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5)) mustBe true
     }
 
     "return false when a date is 2 days away is supplied before 2pm and does not conflict with any bank holidays" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 12, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 3))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 3)) mustBe false
     }
 
 
     // After 2pm, no bank holiday
     "return true when a date 4 days away is supplied after 2pm and does not conflict with any bank holidays" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 15, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 6))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 6)) mustBe true
     }
 
     "return false when a date 3 days away is supplied after 2pm and does not conflict with any bank holidays" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 15, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5)) mustBe false
     }
 
 
     // Before 2pm, bank holiday
     "return true when a date 3 days away is supplied before 2pm and conflicts with one bank holiday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 12, 0), 14, List(bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 5)) mustBe true
     }
 
     "return false when a date 2 days away is supplied before 2pm and conflicts with one bank holiday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 2, 12, 0), 14, List(bh3rd))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 4))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 4)) mustBe false
     }
 
 
     // Weekend, no bank holiday
     "return true when a date is a saturday and the date entered is a wednesday and no bank holiday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 12, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 12))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 12)) mustBe true
     }
 
     "return false when a date is a saturday and the date entered is a tuesday and no bank holiday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 12, 0), 14, List(bhDud))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 10))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 10)) mustBe false
     }
 
 
     // Weekend, bank holiday monday
     "return true when a date is a saturday and the date entered is a thursday with a bank holiday monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 12, 0), 14, List(bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13)) mustBe true
     }
 
     "return false when a date is a saturday and the date entered is a wednesday with a bank holiday monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 12, 0), 14, List(bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11)) mustBe false
     }
 
 
     // Weekend, bank holiday monday, after 2pm
     "return true when a date is a saturday and it is submitted after 2pm and the date entered is a thursday with a bank holiday monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 15, 0), 14, List(bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13)) mustBe true
     }
 
     "return false when a date is a saturday and it is submitted after 2pm and the date entered is a wednesday with a bank holiday monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 7, 15, 0), 14, List(bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11)) mustBe false
     }
 
 
     // Thursday, bank holiday friday, bank holiday monday, after 2pm
     "return true when a date is a thursday and it is submitted after 2pm and the date entered is the next thursday with a bank holiday friday and monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 5, 15, 0), 14, List(bh6th, bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13))(ts.bankHolidays) mustBe true
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 13)) mustBe true
     }
 
     "return false when a date is a thursday and it is submitted after 2pm and the date entered is the next wednesday with a bank holiday friday and monday" in {
       val ts = timeServiceMock(LocalDateTime.of(2017, 1, 5, 15, 0), 14, List(bh6th, bh9th))
-      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11))(ts.bankHolidays) mustBe false
+      ts.isDateSomeWorkingDaysInFuture(LocalDate.of(2017, 1, 11)) mustBe false
     }
   }
 
-  "futureWorkingDate" should {
-    val bankHolidayDates = List(bh3rd, bh6th, bh9th)
-    implicit val bHSTest: BankHolidaySet = BankHolidaySet("england-and-wales", bankHolidayDates)
 
-    "return a future date " in {
-      val ts = timeServiceMock(LocalDateTime.of(2016, 12, 13, 15, 0), 14, bankHolidayDates)
-      ts.futureWorkingDate(60)(bHSTest) mustBe LocalDate.of(2017, 3, 10)
-    }
-    "return a future date ignoring bank holidays" in {
-      val ts = timeServiceMock(LocalDateTime.of(2017, 4, 13, 15, 0), 14, bankHolidayDates)
-      ts.futureWorkingDate(1)(bHSTest) mustBe LocalDate.of(2017, 4, 14)
-    }
-    "return a future date ignoring bank holidays 2 working days in the future" in {
-      val ts = timeServiceMock(LocalDateTime.of(2017, 4, 13, 15, 0), 14, bankHolidayDates)
-      ts.futureWorkingDate(2)(bHSTest) mustBe LocalDate.of(2017, 4, 17)
-    }
-  }
 
   "dynamicDateExample" must {
     val service = new TimeService(mockBankHolidaysConnector, mockCache, mockServicesConfig)

--- a/test/services/VatRegistrationServiceSpec.scala
+++ b/test/services/VatRegistrationServiceSpec.scala
@@ -29,7 +29,6 @@ import testHelpers.{S4LMockSugar, VatRegSpec}
 import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 
 import scala.concurrent.Future
-import scala.language.postfixOps
 
 class VatRegistrationServiceSpec extends VatRegSpec with S4LMockSugar with MockRegistrationApiConnector {
 

--- a/test/views/vatapplication/PaymentFrequencyPageSpec.scala
+++ b/test/views/vatapplication/PaymentFrequencyPageSpec.scala
@@ -21,7 +21,6 @@ import models.api.vatapplication.PaymentFrequency
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import play.api.libs.json.Json
 import views.VatRegViewSpec
 import views.html.vatapplication.payment_frequency
 
@@ -68,7 +67,7 @@ class PaymentFrequencyPageSpec extends VatRegViewSpec {
     }
 
     "show the correct error message if a value isn't selected" in new ViewSetup()(
-      doc = asDocument(PaymentFrequencyForm().bind(Json.obj("value" -> "")))
+      doc = asDocument(PaymentFrequencyForm().bind(Map("value" -> "")))
     ) {
       doc.hasErrorSummary mustBe true
       doc.errorSummaryLinks must contain(Link(ExpectedMessages.error, "#value"))

--- a/test/views/vatapplication/PaymentMethodViewSpec.scala
+++ b/test/views/vatapplication/PaymentMethodViewSpec.scala
@@ -21,7 +21,6 @@ import models.api.vatapplication.PaymentMethod
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import play.api.libs.json.Json
 import views.VatRegViewSpec
 import views.html.vatapplication.aas_payment_method
 
@@ -75,7 +74,7 @@ class PaymentMethodViewSpec extends VatRegViewSpec {
       }
     }
     "show the correct error message if a value isn't selected"in new ViewSetup()(
-      doc = asDocument(PaymentMethodForm().bind(Json.obj("value" -> "")))
+      doc = asDocument(PaymentMethodForm().bind(Map("value" -> "")))
     ) {
       doc.hasErrorSummary mustBe true
       doc.errorSummaryLinks must contain(Link(ExpectedMessages.error, "#value"))


### PR DESCRIPTION
Another big one to remove the majority of the warns caused by:

- Unused parameters
- Unused values
- Incomplete match statements (some still remained but will be handled seperately and carefully)
- Tests

Approx. 25 warns still remain, many of which are caused by the use of the old HTTP Client, which will be handled as part of a separate ticket.

All tests & ATs pass locally.